### PR TITLE
fix(docs): correct sense_resistor for Duet2's onboard TMC2660 channels (0.1 -> 0.051)

### DIFF
--- a/community_mods/mcu/Duet2WiFi.cfg
+++ b/community_mods/mcu/Duet2WiFi.cfg
@@ -17,7 +17,7 @@
 #        cs_pin: Turtle_1:M1_CS
 #        spi_bus: usart1
 #        run_current: 0.8
-#        sense_resistor: 0.051              ← wrong value doesn't fail to boot, it silently scales real motor current
+#        sense_resistor: 0.051
 #        ↑ TMC2660 uses SPI. There is no UART. [tmc2209] with uart_pin will fail at boot.
 #
 #   3. Enable pin — shared across all lanes (Duet WiFi has one TMC_EN pin for all drivers):

--- a/community_mods/mcu/Duet2WiFi.cfg
+++ b/community_mods/mcu/Duet2WiFi.cfg
@@ -17,7 +17,7 @@
 #        cs_pin: Turtle_1:M1_CS
 #        spi_bus: usart1
 #        run_current: 0.8
-#        sense_resistor: 0.1
+#        sense_resistor: 0.051              ← wrong value doesn't fail to boot, it silently scales real motor current
 #        ↑ TMC2660 uses SPI. There is no UART. [tmc2209] with uart_pin will fail at boot.
 #
 #   3. Enable pin — shared across all lanes (Duet WiFi has one TMC_EN pin for all drivers):


### PR DESCRIPTION
**Major Changes**

Corrected the example `sense_resistor` value for the Duet2's onboard TMC2660 drivers (0.1 → 0.051).

**Notes to Code Reviewers**
The Duet2's real TMC2660 sense resistor is 0.051, confirmed against Klipper's own [`generic-duet2-duex.cfg`](https://github.com/Klipper3d/klipper/blob/master/config/generic-duet2-duex.cfg) reference config. The old value (0.1) was double that, so it silently doubled every real motor current. No boot error, no visible symptom. The motor just runs at roughly 2x the current `run_current` implies.

**How tested**
Found while investigating repeated NEMA14 lane motor overheating on our printer (thermistors we installed on the motors confirmed the real temperatures). Traced it to `sense_resistor`: computed the actual current with the driver's own formula and confirmed ~1.36A real against a configured 0.7A. Corrected to `0.051` and re-tuned `run_current` on our live hardware; motors run at the intended current now.

**PR Checklist**: (Checked-off items are either done or do not apply to this PR)

- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [x] Documentation updated in AT-Documentation repository
- [ ] Sent notification to pr-review channel requesting review
- [x] If this PR address a GitHub issue, the issue number is referenced in the PR description

The initial fix was drafted with Claude and then reviewed, tested, and edited by me.