### PR TITLE
(fix): Fix attempted moves and corrupted save state when machine is unhomed

### DIFF
--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -1195,6 +1195,15 @@ class afc:
 
         :param move_z_first: Enable to move z before moving x,y
         """
+        # Only restore position if a valid position was saved, otherwise just return
+        if not self.position_saved:
+            self.function.log_toolhead_pos(
+                f"Not restoring position, Error State: {self.error_state}, "
+                f"Is Paused {self.function.is_paused()}, Position_saved {self.position_saved}, "
+                f"in toolchange: {self.in_toolchange}, POS: "
+            )
+            return
+
         # Only rounded for the log message below, restore logic below uses full precision
         msg = f"Restoring Position {round_floats(self.last_toolhead_position)}"
         msg += f" Base position: {round_floats(self.base_position)}"

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -1143,6 +1143,13 @@ class afc:
         Only save previous location on the first toolchange call to keep an error state from
         overwriting the location
         """
+        if not self.function.is_homed():
+            self.function.log_toolhead_pos(
+                f"Not Saving unhomed position, Error State: {self.error_state}, "
+                f"Is Paused {self.function.is_paused()}, Position_saved {self.position_saved}, "
+                f"in toolchange: {self.in_toolchange}, POS: "
+            )
+            return
         if not self.in_toolchange:
             if (not self.error_state
                 and not self.function.is_paused()

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -1143,7 +1143,7 @@ class afc:
         Only save previous location on the first toolchange call to keep an error state from
         overwriting the location
         """
-        if not self.function.is_homed():
+        if not self.function.is_homed(hardware_only=True):
             self.function.log_toolhead_pos(
                 f"Not Saving unhomed position, Error State: {self.error_state}, "
                 f"Is Paused {self.function.is_paused()}, Position_saved {self.position_saved}, "

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -1143,7 +1143,7 @@ class afc:
         Only save previous location on the first toolchange call to keep an error state from
         overwriting the location
         """
-        if not self.function.is_homed(hardware_only=True):
+        if not self.function.is_homed(for_move=True):
             self.function.log_toolhead_pos(
                 f"Not Saving unhomed position, Error State: {self.error_state}, "
                 f"Is Paused {self.function.is_paused()}, Position_saved {self.position_saved}, "

--- a/extras/AFC_error.py
+++ b/extras/AFC_error.py
@@ -170,7 +170,8 @@ class afcError:
         :param message: error message to log
         """
         self.logger.error(message)
-        if self.afc.function.is_homed(hardware_only=True) and not self.afc.function.is_paused():
+        if self.afc.function.is_homed(for_move=True) \
+            and not self.afc.function.is_paused():
             self.afc.save_pos()
             if self.pause:
                 self.pause_print()
@@ -276,7 +277,8 @@ class afcError:
         move_z_pos = self.afc.last_gcode_position[2] + self.afc.z_hop
         # Check if current position is below saved gcode position, if its lower first raise z above last saved
         #   position so that toolhead does not crash into part
-        if self.afc.function.is_homed(hardware_only=True) and self.afc.gcode_move.last_position[2] <= move_z_pos:
+        if self.afc.function.is_homed(for_move=True) \
+            and self.afc.gcode_move.last_position[2] <= move_z_pos:
             self.afc.move_z_pos(move_z_pos, "AFC_RESUME")
         else:
             self.logger.debug(f"AFC_RESUME: not moving in z cur_pos:{self.afc.gcode_move.last_position} move_z_pos:{move_z_pos}")
@@ -329,7 +331,8 @@ class afcError:
             self.afc.function.check_absolute_mode("AFC_PAUSE")
             move_z_pos = self.afc.last_gcode_position[2] + self.afc.z_hop
             # Check to see if current position is less than saved position plus z-hop
-            if self.afc.function.is_homed(hardware_only=True) and self.afc.gcode_move.last_position[2] <= move_z_pos:
+            if self.afc.function.is_homed(for_move=True) \
+                and self.afc.gcode_move.last_position[2] <= move_z_pos:
                 # Move Z up by z-hop value
                 self.afc.move_z_pos(move_z_pos, "AFC_PAUSE")
             else:

--- a/extras/AFC_error.py
+++ b/extras/AFC_error.py
@@ -276,7 +276,7 @@ class afcError:
         move_z_pos = self.afc.last_gcode_position[2] + self.afc.z_hop
         # Check if current position is below saved gcode position, if its lower first raise z above last saved
         #   position so that toolhead does not crash into part
-        if self.afc.gcode_move.last_position[2] <= move_z_pos:
+        if self.afc.function.is_homed() and self.afc.gcode_move.last_position[2] <= move_z_pos:
             self.afc.move_z_pos(move_z_pos, "AFC_RESUME")
         else:
             self.logger.debug(f"AFC_RESUME: not moving in z cur_pos:{self.afc.gcode_move.last_position} move_z_pos:{move_z_pos}")
@@ -329,7 +329,7 @@ class afcError:
             self.afc.function.check_absolute_mode("AFC_PAUSE")
             move_z_pos = self.afc.last_gcode_position[2] + self.afc.z_hop
             # Check to see if current position is less than saved position plus z-hop
-            if self.afc.gcode_move.last_position[2] <= move_z_pos:
+            if self.afc.function.is_homed() and self.afc.gcode_move.last_position[2] <= move_z_pos:
                 # Move Z up by z-hop value
                 self.afc.move_z_pos(move_z_pos, "AFC_PAUSE")
             else:

--- a/extras/AFC_error.py
+++ b/extras/AFC_error.py
@@ -292,7 +292,9 @@ class afcError:
         # The only time our resume should restore position is if there was an error that caused the pause
         if self.afc.error_state or temp_is_paused or self.afc.position_saved:
             self.set_error_state(False)
-            self.afc.restore_pos(False)
+            # Restore position if the printer is homed, otherwise leave it where it is
+            if self.afc.function.is_homed(for_move=True):
+                self.afc.restore_pos(False)
             self.pause = False
 
         self.logger.debug(

--- a/extras/AFC_error.py
+++ b/extras/AFC_error.py
@@ -170,7 +170,7 @@ class afcError:
         :param message: error message to log
         """
         self.logger.error(message)
-        if self.afc.function.is_homed() and not self.afc.function.is_paused():
+        if self.afc.function.is_homed(hardware_only=True) and not self.afc.function.is_paused():
             self.afc.save_pos()
             if self.pause:
                 self.pause_print()
@@ -276,7 +276,7 @@ class afcError:
         move_z_pos = self.afc.last_gcode_position[2] + self.afc.z_hop
         # Check if current position is below saved gcode position, if its lower first raise z above last saved
         #   position so that toolhead does not crash into part
-        if self.afc.function.is_homed() and self.afc.gcode_move.last_position[2] <= move_z_pos:
+        if self.afc.function.is_homed(hardware_only=True) and self.afc.gcode_move.last_position[2] <= move_z_pos:
             self.afc.move_z_pos(move_z_pos, "AFC_RESUME")
         else:
             self.logger.debug(f"AFC_RESUME: not moving in z cur_pos:{self.afc.gcode_move.last_position} move_z_pos:{move_z_pos}")
@@ -329,7 +329,7 @@ class afcError:
             self.afc.function.check_absolute_mode("AFC_PAUSE")
             move_z_pos = self.afc.last_gcode_position[2] + self.afc.z_hop
             # Check to see if current position is less than saved position plus z-hop
-            if self.afc.function.is_homed() and self.afc.gcode_move.last_position[2] <= move_z_pos:
+            if self.afc.function.is_homed(hardware_only=True) and self.afc.gcode_move.last_position[2] <= move_z_pos:
                 # Move Z up by z-hop value
                 self.afc.move_z_pos(move_z_pos, "AFC_PAUSE")
             else:

--- a/extras/AFC_error.py
+++ b/extras/AFC_error.py
@@ -170,8 +170,8 @@ class afcError:
         :param message: error message to log
         """
         self.logger.error(message)
-        if self.afc.function.is_homed(for_move=True) \
-            and not self.afc.function.is_paused():
+        if (self.afc.function.is_homed(for_move=True)
+            and not self.afc.function.is_paused()):
             self.afc.save_pos()
             if self.pause:
                 self.pause_print()
@@ -277,8 +277,8 @@ class afcError:
         move_z_pos = self.afc.last_gcode_position[2] + self.afc.z_hop
         # Check if current position is below saved gcode position, if its lower first raise z above last saved
         #   position so that toolhead does not crash into part
-        if self.afc.function.is_homed(for_move=True) \
-            and self.afc.gcode_move.last_position[2] <= move_z_pos:
+        if (self.afc.function.is_homed(for_move=True)
+            and self.afc.gcode_move.last_position[2] <= move_z_pos):
             self.afc.move_z_pos(move_z_pos, "AFC_RESUME")
         else:
             self.logger.debug(f"AFC_RESUME: not moving in z cur_pos:{self.afc.gcode_move.last_position} move_z_pos:{move_z_pos}")
@@ -333,8 +333,8 @@ class afcError:
             self.afc.function.check_absolute_mode("AFC_PAUSE")
             move_z_pos = self.afc.last_gcode_position[2] + self.afc.z_hop
             # Check to see if current position is less than saved position plus z-hop
-            if self.afc.function.is_homed(for_move=True) \
-                and self.afc.gcode_move.last_position[2] <= move_z_pos:
+            if (self.afc.function.is_homed(for_move=True)
+                and self.afc.gcode_move.last_position[2] <= move_z_pos):
                 # Move Z up by z-hop value
                 self.afc.move_z_pos(move_z_pos, "AFC_PAUSE")
             else:

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -356,12 +356,12 @@ class afcFunction:
         """
         curtime = self.afc.reactor.monotonic()
         kin_status = self.afc.toolhead.get_kinematics().get_status(curtime)
-        # Always return real homed status if the check is explicitly guarding a move, 
+        # Always return real homed status if the check is explicitly guarding a move,
         # or if homing_check is not disabled in the config
         homing_check = for_move or not self.afc.disable_homing_check
         if homing_check and \
-            ('x' not in kin_status['homed_axes'] 
-            or 'y' not in kin_status['homed_axes'] 
+            ('x' not in kin_status['homed_axes']
+            or 'y' not in kin_status['homed_axes']
             or 'z' not in kin_status['homed_axes']):
             return False
         else:

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -347,18 +347,22 @@ class afcFunction:
         else:
             return True
 
-    def is_homed(self, hardware_only=False):
+    def is_homed(self, for_move=False):
         """
         Helper function to determine if printer is currently homed
 
-        :param hardware_only: When set to True will only return True if the printer is physically homed
+        :param for_move: True if the check is guarding a move, always returning hardware state
         :return boolean: True if xyz is homed
         """
         curtime = self.afc.reactor.monotonic()
         kin_status = self.afc.toolhead.get_kinematics().get_status(curtime)
-        homing_check = hardware_only or not self.afc.disable_homing_check
-        if ('x' not in kin_status['homed_axes'] or 'y' not in kin_status['homed_axes'] or 'z' not in kin_status['homed_axes']) and \
-            homing_check:
+        # Always return real homed status if the check is explicitly guarding a move, 
+        # or if homing_check is not disabled in the config
+        homing_check = for_move or not self.afc.disable_homing_check
+        if homing_check and \
+            ('x' not in kin_status['homed_axes'] 
+            or 'y' not in kin_status['homed_axes'] 
+            or 'z' not in kin_status['homed_axes']):
             return False
         else:
             return True

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -347,16 +347,18 @@ class afcFunction:
         else:
             return True
 
-    def is_homed(self):
+    def is_homed(self, hardware_only=False):
         """
         Helper function to determine if printer is currently homed
 
+        :param hardware_only: When set to True will only return True if the printer is physically homed
         :return boolean: True if xyz is homed
         """
         curtime = self.afc.reactor.monotonic()
         kin_status = self.afc.toolhead.get_kinematics().get_status(curtime)
+        homing_check = hardware_only or not self.afc.disable_homing_check
         if ('x' not in kin_status['homed_axes'] or 'y' not in kin_status['homed_axes'] or 'z' not in kin_status['homed_axes']) and \
-            not self.afc.disable_homing_check:
+            homing_check:
             return False
         else:
             return True

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -359,10 +359,10 @@ class afcFunction:
         # Always return real homed status if the check is explicitly guarding a move,
         # or if homing_check is not disabled in the config
         homing_check = for_move or not self.afc.disable_homing_check
-        if homing_check and \
+        if (homing_check and
             ('x' not in kin_status['homed_axes']
             or 'y' not in kin_status['homed_axes']
-            or 'z' not in kin_status['homed_axes']):
+            or 'z' not in kin_status['homed_axes'])):
             return False
         else:
             return True

--- a/tests/test_AFC.py
+++ b/tests/test_AFC.py
@@ -3148,6 +3148,51 @@ class TestRestorePos:
         )
         assert calls[2].args[0] == expected_final
 
+    def test_does_not_restore_when_position_not_saved(self):
+        """When position_saved is False, restore_pos returns immediately without
+        touching gcode_move state, moving the toolhead, or changing current_state."""
+        obj = _make_afc_for_restore_pos()
+        obj.position_saved = False
+        obj.current_state = State.IDLE
+
+        obj.restore_pos(move_z_first=False)
+
+        assert obj.position_saved is False
+        assert obj.current_state == State.IDLE
+        obj.move_z_pos.assert_not_called()
+        obj.gcode_move.move_with_transform.assert_not_called()
+        obj.function.log_toolhead_pos.assert_called_once()
+        debug_msgs = [m for lvl, m in obj.logger.messages if lvl == "debug"]
+        assert debug_msgs == []
+
+    def test_does_not_restore_when_position_not_saved_move_z_first_true(self):
+        """The position_saved guard applies before the move_z_first branch is
+        ever reached, regardless of which value is passed."""
+        obj = _make_afc_for_restore_pos()
+        obj.position_saved = False
+
+        obj.restore_pos(move_z_first=True)
+
+        obj.move_z_pos.assert_not_called()
+        obj.gcode_move.move_with_transform.assert_not_called()
+
+    def test_logs_not_restoring_message_when_position_not_saved(self):
+        """Verifies the exact log_toolhead_pos() call made on the not-saved branch."""
+        obj = _make_afc_for_restore_pos()
+        obj.position_saved = False
+        obj.in_toolchange = False
+        obj.error_state = False
+        obj.function.is_paused.return_value = False
+
+        obj.restore_pos(move_z_first=False)
+
+        expected = (
+            f"Not restoring position, Error State: {obj.error_state}, "
+            f"Is Paused {obj.function.is_paused()}, Position_saved {obj.position_saved}, "
+            f"in toolchange: {obj.in_toolchange}, POS: "
+        )
+        obj.function.log_toolhead_pos.assert_called_once_with(expected)
+
 
 # in_print_reactor_timer: moonraker None guard
 

--- a/tests/test_AFC.py
+++ b/tests/test_AFC.py
@@ -2948,6 +2948,41 @@ class TestSavePos:
         )
         obj.function.log_toolhead_pos.assert_called_once_with(expected)
 
+    def test_does_not_save_when_not_homed(self):
+        """When function.is_homed(hardware_only=True) returns False, save_pos returns
+        immediately without inspecting in_toolchange/error_state/is_paused/position_saved."""
+        obj = _make_afc_for_save_pos()
+        obj.in_toolchange = False
+        obj.error_state = False
+        obj.function.is_paused.return_value = False
+        obj.function.is_homed.return_value = False
+        obj.position_saved = False
+
+        obj.save_pos()
+
+        assert obj.position_saved is False
+        assert not hasattr(obj, "last_toolhead_position")
+        obj.function.is_homed.assert_called_once_with(hardware_only=True)
+        obj.function.log_toolhead_pos.assert_called_once()
+
+    def test_logs_not_saving_unhomed_message(self):
+        """Verifies the exact log_toolhead_pos() call made on the not-homed branch."""
+        obj = _make_afc_for_save_pos()
+        obj.in_toolchange = False
+        obj.error_state = False
+        obj.function.is_paused.return_value = False
+        obj.function.is_homed.return_value = False
+        obj.position_saved = False
+
+        obj.save_pos()
+
+        expected = (
+            f"Not Saving unhomed position, Error State: {obj.error_state}, "
+            f"Is Paused {obj.function.is_paused()}, Position_saved {obj.position_saved}, "
+            f"in toolchange: {obj.in_toolchange}, POS: "
+        )
+        obj.function.log_toolhead_pos.assert_called_once_with(expected)
+
     def test_does_not_save_when_in_toolchange(self):
         """When in_toolchange is True, the outer branch is taken regardless of
         error_state/is_paused/position_saved."""

--- a/tests/test_AFC.py
+++ b/tests/test_AFC.py
@@ -3154,14 +3154,26 @@ class TestRestorePos:
         obj = _make_afc_for_restore_pos()
         obj.position_saved = False
         obj.current_state = State.IDLE
+        obj.function.is_paused.return_value = False
+        last_position_before = list(obj.gcode_move.last_position)
+        base_position_before = list(obj.gcode_move.base_position)
 
         obj.restore_pos(move_z_first=False)
 
         assert obj.position_saved is False
         assert obj.current_state == State.IDLE
+        assert obj.gcode_move.last_position == last_position_before
+        assert obj.gcode_move.base_position == base_position_before
         obj.move_z_pos.assert_not_called()
         obj.gcode_move.move_with_transform.assert_not_called()
-        obj.function.log_toolhead_pos.assert_called_once()
+
+        expected = (
+            f"Not restoring position, Error State: {obj.error_state}, "
+            f"Is Paused {obj.function.is_paused.return_value}, "
+            f"Position_saved {obj.position_saved}, "
+            f"in toolchange: {obj.in_toolchange}, POS: "
+        )
+        obj.function.log_toolhead_pos.assert_called_once_with(expected)
         debug_msgs = [m for lvl, m in obj.logger.messages if lvl == "debug"]
         assert debug_msgs == []
 

--- a/tests/test_AFC.py
+++ b/tests/test_AFC.py
@@ -2949,7 +2949,7 @@ class TestSavePos:
         obj.function.log_toolhead_pos.assert_called_once_with(expected)
 
     def test_does_not_save_when_not_homed(self):
-        """When function.is_homed(hardware_only=True) returns False, save_pos returns
+        """When function.is_homed(for_move=True) returns False, save_pos returns
         immediately without inspecting in_toolchange/error_state/is_paused/position_saved."""
         obj = _make_afc_for_save_pos()
         obj.in_toolchange = False
@@ -2962,7 +2962,7 @@ class TestSavePos:
 
         assert obj.position_saved is False
         assert not hasattr(obj, "last_toolhead_position")
-        obj.function.is_homed.assert_called_once_with(hardware_only=True)
+        obj.function.is_homed.assert_called_once_with(for_move=True)
         obj.function.log_toolhead_pos.assert_called_once()
 
     def test_logs_not_saving_unhomed_message(self):

--- a/tests/test_AFC_functions.py
+++ b/tests/test_AFC_functions.py
@@ -452,6 +452,70 @@ class TestAfcDeltaTime:
         dt.log_with_time("safe call")
 
 
+# ── is_homed ──────────────────────────────────────────────────────────────────
+
+class TestIsHomed:
+    def _wire(self, func, homed_axes, disable_homing_check):
+        """Wire up func.afc.toolhead.get_kinematics().get_status() to report
+        `homed_axes` (a string such as "xyz", "xy", or "") and set
+        func.afc.disable_homing_check."""
+        func.afc.disable_homing_check = disable_homing_check
+        kin = MagicMock()
+        kin.get_status.return_value = {"homed_axes": homed_axes}
+        func.afc.toolhead.get_kinematics.return_value = kin
+
+    @pytest.mark.parametrize(
+        "hardware_only,disable_homing_check,homed_axes,expected",
+        [
+            # hardware_only=True: homing_check is always True, disable_homing_check
+            # is ignored entirely, and each individually-missing axis returns False.
+            (True, False, "xyz", True),
+            (True, False, "xy", False),
+            (True, False, "xz", False),
+            (True, False, "yz", False),
+            (True, False, "", False),
+            (True, True, "xyz", True),
+            (True, True, "xy", False),
+            (True, True, "xz", False),
+            (True, True, "yz", False),
+            (True, True, "", False),
+            # hardware_only=False, disable_homing_check=False: homing_check is True,
+            # so behavior matches the hardware_only=True/disable_homing_check=False case.
+            (False, False, "xyz", True),
+            (False, False, "xy", False),
+            (False, False, "xz", False),
+            (False, False, "yz", False),
+            (False, False, "", False),
+            # hardware_only=False, disable_homing_check=True: homing_check is False,
+            # so the result is always True regardless of which axes are homed.
+            (False, True, "xyz", True),
+            (False, True, "xy", True),
+            (False, True, "xz", True),
+            (False, True, "yz", True),
+            (False, True, "", True),
+        ],
+    )
+    def test_all_permutations(self, hardware_only, disable_homing_check, homed_axes, expected):
+        func = _make_func()
+        self._wire(func, homed_axes, disable_homing_check)
+        assert func.is_homed(hardware_only=hardware_only) is expected
+
+    def test_default_hardware_only_is_false(self):
+        """hardware_only defaults to False, so it should behave like the
+        hardware_only=False cases above when called with no argument."""
+        func = _make_func()
+        self._wire(func, homed_axes="xy", disable_homing_check=False)
+        assert func.is_homed() is False
+
+        func = _make_func()
+        self._wire(func, homed_axes="xyz", disable_homing_check=False)
+        assert func.is_homed() is True
+
+        func = _make_func()
+        self._wire(func, homed_axes="xy", disable_homing_check=True)
+        assert func.is_homed() is True
+
+
 # ── _rename ───────────────────────────────────────────────────────────────────
 
 class TestRename:

--- a/tests/test_AFC_functions.py
+++ b/tests/test_AFC_functions.py
@@ -465,9 +465,9 @@ class TestIsHomed:
         func.afc.toolhead.get_kinematics.return_value = kin
 
     @pytest.mark.parametrize(
-        "hardware_only,disable_homing_check,homed_axes,expected",
+        "for_move,disable_homing_check,homed_axes,expected",
         [
-            # hardware_only=True: homing_check is always True, disable_homing_check
+            # for_move=True: homing_check is always True, disable_homing_check
             # is ignored entirely, and each individually-missing axis returns False.
             (True, False, "xyz", True),
             (True, False, "xy", False),
@@ -479,14 +479,14 @@ class TestIsHomed:
             (True, True, "xz", False),
             (True, True, "yz", False),
             (True, True, "", False),
-            # hardware_only=False, disable_homing_check=False: homing_check is True,
-            # so behavior matches the hardware_only=True/disable_homing_check=False case.
+            # for_move=False, disable_homing_check=False: homing_check is True,
+            # so behavior matches the for_move=True/disable_homing_check=False case.
             (False, False, "xyz", True),
             (False, False, "xy", False),
             (False, False, "xz", False),
             (False, False, "yz", False),
             (False, False, "", False),
-            # hardware_only=False, disable_homing_check=True: homing_check is False,
+            # for_move=False, disable_homing_check=True: homing_check is False,
             # so the result is always True regardless of which axes are homed.
             (False, True, "xyz", True),
             (False, True, "xy", True),
@@ -495,14 +495,14 @@ class TestIsHomed:
             (False, True, "", True),
         ],
     )
-    def test_all_permutations(self, hardware_only, disable_homing_check, homed_axes, expected):
+    def test_all_permutations(self, for_move, disable_homing_check, homed_axes, expected):
         func = _make_func()
         self._wire(func, homed_axes, disable_homing_check)
-        assert func.is_homed(hardware_only=hardware_only) is expected
+        assert func.is_homed(for_move=for_move) is expected
 
-    def test_default_hardware_only_is_false(self):
-        """hardware_only defaults to False, so it should behave like the
-        hardware_only=False cases above when called with no argument."""
+    def test_default_for_move_is_true(self):
+        """for_move defaults to True, so it should behave like the
+        for_move=True cases above when called with no argument."""
         func = _make_func()
         self._wire(func, homed_axes="xy", disable_homing_check=False)
         assert func.is_homed() is False

--- a/tests/test_AFC_functions.py
+++ b/tests/test_AFC_functions.py
@@ -500,9 +500,9 @@ class TestIsHomed:
         self._wire(func, homed_axes, disable_homing_check)
         assert func.is_homed(for_move=for_move) is expected
 
-    def test_default_for_move_is_true(self):
-        """for_move defaults to True, so it should behave like the
-        for_move=True cases above when called with no argument."""
+    def test_default_for_move_is_false(self):
+        """for_move defaults to False, so it should behave like the
+        for_move=False cases above when called with no argument."""
         func = _make_func()
         self._wire(func, homed_axes="xy", disable_homing_check=False)
         assert func.is_homed() is False


### PR DESCRIPTION
Presently, calling `PAUSE` when the machine isn't homed (in a startup routine for example) causes the saved position state to become corrupted. Additionally, when PAUSE or RESUME are fired with an unhomed machine, they blindly attempt to move (z-hop) and cause an error which terminates the action.

## Major Changes in this PR

This PR introduces 2 changes: 

1) Only `save_pos()` if the machine is homed, and hence the current position is valid. Otherwise ignore the call.

2) On `PAUSE` and `RESUME`, check to ensure that the machine is homed before attempting any moves.

## Notes to Code Reviewers

## How the changes in this PR are tested

Before: 

klippy.log:
```
9:34 AM PAUSE
9:34 AM // action:paused
9:34 AM !! Must home axis first: 0.000 0.000 5.000 [0.000]
```

AFC.log
```
14:34:28 2074734.056 [AFC_error.py:cmd_AFC_PAUSE():249]         - DEBUG:AFC_PAUSE: Pausing
14:34:28 2074734.056 [AFC.py:save_pos():1113]                   - DEBUG:Saving position [0.0, 0.0, 0.0, 0.0] Base position: [0.0, 0.0, 0.0, 0.0] last_gcode_position: [0.0, 0.0, 0.0, 0.0] homing_position: [0.0, 0.0, 0.0, 0.0] speed: 25.0 speed_factor: 0.016667 absolute_coord: True absolute_extrude: True extrude_factor: 1.0
14:34:28 2074734.058 [AFC_functions.py:log_toolhead_pos():618]  - DEBUG:AFC_PAUSE: check absolute mode, POS:Position: [0.0, 0.0, 0.0, 0.0] base_position: [0.0, 0.0, 0.0, 0.0] last_position: [0.0, 0.0, 0.0, 0.0] speed: 25.0 speed_factor: 0.016667 extrude_factor: 1.0 absolute_coord: True absolute_extrude: True
```

After:

klippy.log:
```
9:37 AM PAUSE
9:37 AM // action:paused
9:37 AM // idle_timeout: Timeout set to 36000.00 s
```

AFC.log
```
14:37:41 2074926.628 [AFC_error.py:cmd_AFC_PAUSE():249]         - DEBUG:AFC_PAUSE: Pausing
14:37:41 2074926.633 [AFC_functions.py:log_toolhead_pos():618]  - DEBUG:Not Saving unhomed position, Error State: False, Is Paused False, Position_saved False, in toolchange: False, POS: Position: [0.0, 0.0, 0.0, 0.0] base_position: [0.0, 0.0, 0.0, 0.0] last_position: [0.0, 0.0, 0.0, 0.0] speed: 25.0 speed_factor: 0.016667 extrude_factor: 1.0 absolute_coord: True absolute_extrude: True
14:37:41 2074926.642 [AFC_functions.py:log_toolhead_pos():618]  - DEBUG:AFC_PAUSE: check absolute mode, POS:Position: [0.0, 0.0, 0.0, 0.0] base_position: [0.0, 0.0, 0.0, 0.0] last_position: [0.0, 0.0, 0.0, 0.0] speed: 25.0 speed_factor: 0.016667 extrude_factor: 1.0 absolute_coord: True absolute_extrude: True
14:37:41 2074926.643 [AFC_error.py:cmd_AFC_PAUSE():249]         - DEBUG:AFC_PAUSE: not moving in z cur_pos:[0.0, 0.0, 0.0, 0.0] move_z_pos:5.0
14:37:41 2074926.664 [AFC_error.py:cmd_AFC_PAUSE():249]         - DEBUG:PAUSE-Error State: False, Is Paused True, Position_saved False, in toolchange: False
```

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [X] I have performed a self-review of my code
- [ ] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [ ] Sent notification to pr-review channel requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated AFC to version 1.2.5.
  * Added support for multiple lane mappings and expanded temperature, configuration, status, and display-status information.
  * Display macros now provide updates during tool loading and unloading.
* **Bug Fixes**
  * Improved recovery messaging and tracking for failed load, unload, and tool-change operations.
  * Added warnings when lane ejection is refused.
  * Improved homing checks for safer position saving and recovery movements.
  * Prevented recovery moves when no valid saved position is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->