### PR TITLE
Fix tool temperature resolution for custom lane maps and lane-less toolheads (IDEX)

### DIFF
--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -729,7 +729,10 @@ class afc:
                 # in which case fall back to the toolhead extruder index so multi-toolhead
                 # setups still resolve the correct per-tool temperature.
                 try:
-                    idx = int(str(cur_lane.current_map).lstrip("T"))
+                    map_match = re.fullmatch(r"T(\d+)", str(cur_lane.current_map))
+                    if map_match is None:
+                        raise ValueError("current_map is not in T<n> form")
+                    idx = int(map_match.group(1))
                 except (ValueError, TypeError):
                     idx = cur_lane.lane_extruder_index
                 if idx < 0: raise ValueError("Negative tool index")

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -725,8 +725,13 @@ class afc:
             try:
                 # cur_lane.current_map is expected to be the tool number as "T<n>" (e.g. "T3"),
                 # used here as the index into print_tool_temperatures from the sliced
-                # file's metadata. Custom user-assigned maps may not follow this format.
-                idx = int(str(cur_lane.current_map).lstrip("T"))
+                # file's metadata. Custom user-assigned maps may not follow this format,
+                # in which case fall back to the toolhead extruder index so multi-toolhead
+                # setups still resolve the correct per-tool temperature.
+                try:
+                    idx = int(str(cur_lane.current_map).lstrip("T"))
+                except (ValueError, TypeError):
+                    idx = cur_lane.lane_extruder_index
                 if idx < 0: raise ValueError("Negative tool index")
                 target_temp = self.print_tool_temperatures[idx]
             except (ValueError, IndexError, TypeError, AttributeError) as e:

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -2800,8 +2800,18 @@ class afc:
                     self.logger.error("extruder not configured for T{}".format(toolnum))
                     return
             else:
-                self.logger.error("extruder not configured for T{}".format(toolnum))
-                return
+                # No lane is mapped as T<n> (custom lane commands such as BT1..BT4).
+                # Fall back to stock Klipper semantics, T<n> -> extruder<n>, so
+                # toolheads without an AFC lane still receive their temperature
+                # (e.g. the primary extruder on an IDEX printer).
+                th_extruder_name = "extruder" if toolnum == 0 else f"extruder{toolnum}"
+                extruder = self.tools.get(th_extruder_name, None)
+                if extruder is None:
+                    extruder = self.printer.lookup_object(th_extruder_name, None)
+                if extruder is None:
+                    self.logger.error("extruder not configured for T{}".format(toolnum))
+                    return
+                self.logger.info("Lane map {} not found, setting temperature for {}".format(map, th_extruder_name))
         else:
             extruder = self.toolhead.get_extruder()
 


### PR DESCRIPTION
## Problem

Two places in AFC assume a lane's map always follows the `T<n>` convention:

**1. `_check_extruder_temp()`** parses `cur_lane.current_map` as `T<n>` to index `print_tool_temperatures` taken from the sliced file's metadata. With custom lane commands (e.g. `cmd: BT1`, used on multi-toolhead printers where BoxTurtle lanes are addressed as `BT<n>` and the slicer's `T<n>` selects toolheads) the parse fails, the exception is swallowed and the per-tool temperature from the slicer is silently never applied.

**2. `cmd_AFC_M109()` (and M104)** resolves `T<n>` through lane maps only. When no lane is mapped as `T<n>` (same custom-map setups) it logs `extruder not configured for T<n>` and drops the temperature command entirely. On an IDEX printer whose primary extruder has no AFC lanes at all (all lanes feed the secondary toolhead), the primary extruder never receives any `M104`/`M109` from the slicer.

## Changes

- `_check_extruder_temp()`: keep parsing `T<n>` as before; when `current_map` does not parse as a tool number, fall back to the lane's `lane_extruder_index()` (toolhead extruder name to index). Standard `T<n>` setups keep the existing behavior; only custom-map lanes change.
- `cmd_AFC_M109()`: when no lane matches `T<n>`, fall back to stock Klipper semantics `T<n> -> extruder<n>` (mirroring the existing Snapmaker branch): look the extruder up among AFC tools first, then directly among the printer config objects. Toolheads without AFC lanes now get their temperature instead of a dropped command.

## Testing

Verified on a Tridex-style IDEX printer: 4 BoxTurtle lanes (`cmd: BT1..BT4`) all feeding `extruder1`, plain `extruder` as the primary toolhead, slicer emits `T0`/`T1`:

- `M104 T0 S<n>` sets the target on `extruder` (printer-object lookup path)
- `M104 T1 S<n>` sets the target on `extruder1` (AFC tools path)
- klippy starts clean, all MCUs connect, no errors in logs
- logic checks: `T<n>` maps (single and multi-map lanes) are unchanged; custom maps resolve through the toolhead extruder; exotic extruder names degrade gracefully via `lane_extruder_index()`

## AI assistance disclosure

> [!WARNING]
> Parts of this change were written with the assistance of an AI model (GLM-5.3 by Z.ai). The code was reviewed and verified by the contributor on real hardware before submitting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved per-tool print temperature selection when a lane’s custom tool mapping is invalid or unavailable.
  * Added fallback to the lane’s configured extruder for more reliable temperature lookups.
  * Temperature commands now correctly use the corresponding stock extruder when no lane is mapped.
  * Improved validation of tool mappings to prevent incorrect temperature selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->