### PR TITLE
(fix): Support GCodeMove.allow_absolute_extrude rename in Klipper master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- AFC no longer crashes with `AttributeError: 'GCodeMove' object has no attribute 'absolute_extrude'`
+  during tool changes on current Klipper master builds. Klipper moved `GCodeMove` to
+  `klippy/extras/gcode_move.py` and renamed the attribute to `allow_absolute_extrude`
+  (v0.13.0-708 and newer); AFC now reads and restores whichever attribute name the host
+  provides, so it keeps working on older and newer Klipper alike.
+
+
 ## [2026-08-15]
 ### Breaking Change
 - `RESET_AFC_MAPPING` has now been renamed to `AFC_RESET_MAPPING`

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -1155,7 +1155,9 @@ class afc:
                 self.speed                  = self.gcode_move.speed
                 self.speed_factor           = self.gcode_move.speed_factor
                 self.absolute_coord         = self.gcode_move.absolute_coord
-                self.absolute_extrude       = self.gcode_move.absolute_extrude
+                # Klipper master renamed absolute_extrude -> allow_absolute_extrude
+                self.absolute_extrude       = getattr(self.gcode_move, "allow_absolute_extrude",
+                                                       getattr(self.gcode_move, "absolute_extrude", True))
                 self.extrude_factor         = self.gcode_move.extrude_factor
                 # Only rounded for the log message below, stored position values keep full precision
                 msg = f"Saving position {round_floats(self.last_toolhead_position)}"
@@ -1219,7 +1221,8 @@ class afc:
 
         # Restore absolute coords
         self.gcode_move.absolute_coord      = self.absolute_coord
-        self.gcode_move.absolute_extrude    = self.absolute_extrude
+        setattr(self.gcode_move, "allow_absolute_extrude" if hasattr(self.gcode_move, "allow_absolute_extrude")
+                else "absolute_extrude", self.absolute_extrude)
         self.gcode_move.extrude_factor      = self.extrude_factor
         self.gcode_move.speed               = self.speed
         self.gcode_move.speed_factor        = self.speed_factor

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -661,7 +661,7 @@ class afcFunction:
         msg += f" speed_factor: {round_floats(self.afc.gcode_move.speed_factor)}"
         msg += f" extrude_factor: {round_floats(self.afc.gcode_move.extrude_factor)}"
         msg += f" absolute_coord: {self.afc.gcode_move.absolute_coord}"
-        msg += f" absolute_extrude: {self.afc.gcode_move.absolute_extrude}\n"
+        msg += f" absolute_extrude: {getattr(self.afc.gcode_move, 'allow_absolute_extrude', getattr(self.afc.gcode_move, 'absolute_extrude', True))}\n"
         self.logger.debug(msg, only_debug=True)
 
     def check_absolute_mode( self, func_name:str="" ):
@@ -677,9 +677,11 @@ class afcFunction:
         if not self.afc.gcode_move.absolute_coord:
             self.logger.debug("Printer coords not in absolute mode, setting to absolute mode")
             self.afc.gcode_move.absolute_coord = True
-        if not self.afc.gcode_move.absolute_extrude:
+        extrude_attr = "allow_absolute_extrude" if hasattr(self.afc.gcode_move, "allow_absolute_extrude") \
+                       else "absolute_extrude"
+        if not getattr(self.afc.gcode_move, extrude_attr):
             self.logger.debug("Printer extruder not in absolute mode, setting to absolute mode")
-            self.afc.gcode_move.absolute_extrude = True
+            setattr(self.afc.gcode_move, extrude_attr, True)
 
     def get_extruder_pos(self, eventtime=None, past_extruder_position=None, extruder=None):
         """


### PR DESCRIPTION
## Major Changes in this PR

Klipper master (v0.13.0-708 and newer, commit 1286d300) moved the `GCodeMove` class to `klippy/extras/gcode_move.py` and renamed its `absolute_extrude` attribute to `allow_absolute_extrude`.

AFC reads and writes `gcode_move.absolute_extrude` in four places (position save/restore around tool changes, debug position logging, and `check_absolute_mode`). On current Klipper builds any tool change raises:

```
AttributeError: 'GCodeMove' object has no attribute 'absolute_extrude'. Did you mean: 'absolute_coord'?
```

This happens inside `CHANGE_TOOL` and sends klippy into shutdown mid tool change - the head stops and the printer needs a restart. The same crash reproduces on both `main` (v1.2.0) and `DEV`.

This PR reads/restores whichever attribute name the running host provides (`allow_absolute_extrude` if present, otherwise the old `absolute_extrude`), so AFC works on both older and newer Klipper.

## Notes to Code Reviewers

- The change is intentionally minimal: 4 sites, +10/-5 lines, no behavior change on Klipper builds that still have the old attribute.
- The `True` fallback in the `getattr` chain only applies if some future Klipper removes both names; it matches the pre-move default (absolute extrusion on).
- Not tied to a GitHub issue - I did not find an existing one for this crash.

## How the changes in this PR are tested

- Real hardware: Tridex-style IDEX printer, AFC with a Toolchanger unit (standalone left toolhead + BoxTurtle feeding the right toolhead), Klipper v0.13.0-743 (current master).
- Before the fix: first `T<n>` tool change after PREP crashed with the AttributeError above and klippy entered shutdown.
- After the fix: full tool changes (head swap with lane load/unload, cut, purge) complete normally; `check_absolute_mode` logging prints the mode correctly; multiple consecutive T changes verified.
- `python3 -m py_compile` clean on both touched files.

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [ ] Sent notification to pr-review channel requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

Documentation: no user-facing config options changed, so no doc update needed as far as I can tell - happy to add one if reviewers disagree. I have not sent the pr-review channel notification yet; will do once maintainers confirm which channel is preferred.

---

*Note: parts of this change were written with the assistance of an AI model (GLM-5.3 by Z.ai) and were reviewed and verified by me on real hardware before submitting.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility across older and newer Klipper versions.
  * Toolhead position saving and restoration now works correctly with updated Klipper extrusion settings.
  * Extruder-mode validation and logging now recognize both legacy and renamed Klipper settings.
* **Documentation**
  * Added an Unreleased changelog entry describing the expanded Klipper compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->