### PR TITLE
(feat): Adding ability for AFC to call led effects macros

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,9 @@
+<!--
+Please fill out this template yourself, in your own words, matching its sections and
+checklist below. Do not paste in an AI/LLM-generated PR description or reformat this
+template to something else.
+-->
+
 ## Major Changes in this PR
 
 ## Notes to Code Reviewers
@@ -12,6 +18,6 @@
 - [ ] Sent notification to pr-review channel requesting review
 - [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description
 
-**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
+**NOTE**: Coderabbitai may be used for automated code reviews, however as it is an automated system, it's suggestions 
 may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
 own judgement to determine if they are correct.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,6 +18,7 @@ template to something else.
 - [ ] Sent notification to pr-review channel requesting review
 - [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description
 
-**NOTE**: Coderabbitai may be used for automated code reviews, however as it is an automated system, it's suggestions 
-may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
+**NOTE**: Coderabbitai may be used for automated code reviews.
+It is an automated system, so its suggestions may not be correct.
+Do not rely on it to catch all issues. Review its suggestions and use your
 own judgement to determine if they are correct.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,11 +13,13 @@
    surrounding file's conventions rather than imposing a different style.
 - **Correct typing** — including things like `Optional[float]` instead of
    `float = None`. Methods should be fully annotated (parameters and return
-   type). Local variables and attributes only need an explicit annotation
-   when a linter/type checker (e.g. mypy) can't infer the type on its own —
-   for example an attribute first assigned `None` and later assigned a
-   concrete type elsewhere, or an empty `{}`/`[]` whose element type isn't
-   obvious from that line alone.
+   type). This applies to actual code (`extras/*.py` and similar); unit test
+   methods may be annotated too, but it's optional there, not required.
+   Local variables and attributes only need an explicit annotation when a
+   linter/type checker (e.g. mypy) can't infer the type on its own — for
+   example an attribute first assigned `None` and later assigned a concrete
+   type elsewhere, or an empty `{}`/`[]` whose element type isn't obvious
+   from that line alone.
 - **Use f-strings, not `str.format()`** — `f"Lane {self.name}"` rather than
    `"Lane {}".format(self.name)`.
 - **Format error/exception strings before raising, not inline** — build the
@@ -36,7 +38,10 @@
    still need to make sense to the developer reading them, just don't let
    them turn into paragraphs.
 - **No em-dashes.** Use a period, comma, or colon instead when breaking up a
-   clause, in comments, docstrings, commit messages, or any other prose.
+   clause, in comments, docstrings, commit messages, or any other prose. This
+   applies to new code and documentation, and to existing documentation while
+   it's being edited (clean up any em-dashes in a doc you're already touching,
+   but don't go sweep unrelated files just for this).
 - **Docstrings** — every new or changed method needs a docstring matching
    Sphinx-style convention in this shape: a short description, a blank line,
    then one `:param name:` per parameter (skip `self`) and a `:return type:`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,8 @@
 - **Keep comments short and succinct** — a sentence or two at most. Comments
    still need to make sense to the developer reading them, just don't let
    them turn into paragraphs.
+- **No em-dashes.** Use a period, comma, or colon instead when breaking up a
+   clause, in comments, docstrings, commit messages, or any other prose.
 - **Docstrings** — every new or changed method needs a docstring matching
    Sphinx-style convention in this shape: a short description, a blank line,
    then one `:param name:` per parameter (skip `self`) and a `:return type:`
@@ -160,3 +162,12 @@
 These apply together — for example, a test written to satisfy the
 multi-condition independence rule still has to satisfy the class-variable,
 logging, and branch-coverage rules for that same test.
+
+# Pull Request Rules
+
+- **AI/LLMs must not write the PR description.** The user has to fill out
+   `.github/pull_request_template.md` themselves, in their own words, matching
+   the template's sections and checklist. Do not draft, generate, or rewrite
+   a PR title/description on their behalf, even if asked to summarize the
+   changes for them to use elsewhere, that summary is not a substitute for
+   the user completing the template.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-08-22]
+### Added
+- Lane and extruder status LEDs can now overlay a `SET_LED_EFFECT` animation on top of the usual
+  static color. Define a `led_effect <lane_or_extruder_name>_<state>` object and it's triggered
+  automatically when that lane/extruder reaches the matching state. Only that lane/extruder's
+  own effect is stopped on the next state change, and re-applying an unchanged state is now a
+  no-op. Nothing changes for lanes without a matching effect defined.
+- Added `templates/led_effects_examples.cfg` with example configs for the feature above.
+
+### Fixed
+- A few status LED updates (toolchanger tool-select, ViViD calibration, lane fault) now go through
+  the same lane LED methods as everything else, so they pick up effects/colors consistently too.
+
 ## [2026-08-15]
 ### Breaking Change
 - `RESET_AFC_MAPPING` has now been renamed to `AFC_RESET_MAPPING`

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -1389,6 +1389,7 @@ class afc:
             # Setting status as ejecting so if filament is removed and de-activates the prep sensor while
             # extruder motors are still running it does not trigger infinite spool or pause logic
             # once user removes filament lanes status will go to None
+            cur_lane.unit_obj.lane_unloading(cur_lane)
             cur_lane.status = AFCLaneState.EJECTING
             self.save_vars()
 
@@ -1405,7 +1406,7 @@ class afc:
             # Removing spool from vars since it was ejected
             self.spool.set_spoolID(cur_lane, None)
             self.logger.info("LANE {} eject done".format(cur_lane.name))
-            cur_lane.unit_obj.lane_not_ready(cur_lane)
+            cur_lane.unit_obj.lane_unloaded(cur_lane)
         elif cur_lane.extruder_obj.is_standalone() and cur_lane.extruder_obj.lane_loaded:
             cur_lane.status = AFCLaneState.EJECTING
             cur_lane.extruder_obj.load_unload_sequence(cur_lane.extruder_obj.tool_stn_unload*-1)
@@ -1821,6 +1822,7 @@ class afc:
             cur_lane.status = AFCLaneState.TOOL_LOADED
             self.save_vars()
             cur_lane.sync_to_extruder()
+            cur_lane.unit_obj.lane_tool_loaded_gears(cur_lane)
 
             if cur_extruder.tool_end:
                 while not cur_extruder.tool_end_state:
@@ -2319,7 +2321,7 @@ class afc:
 
             # Finalize unloading and reset lane state.
             cur_lane.loaded_to_hub = True
-            cur_lane.unit_obj.lane_tool_unloaded(cur_lane)
+            cur_lane.unit_obj.lane_loaded(cur_lane)
             cur_lane.status = AFCLaneState.NONE
 
             if (cur_lane.is_direct_hub()

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -130,6 +130,7 @@ class afc:
         self.number_of_toolchanges  = 0
         self.current_toolchange     = 0
         self.print_tool_temperatures: List[int] = []
+        self.active_led_effects: List[str] = []
 
         # tool position when tool change was requested
         self.change_tool_pos = None

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -46,7 +46,7 @@ except: raise error(ERROR_STR.format(import_lib="AFC_utils", trace=traceback.for
 try: from extras.AFC_stats import AFCStats
 except: raise error(ERROR_STR.format(import_lib="AFC_stats", trace=traceback.format_exc()))
 
-AFC_VERSION="1.2.5"
+AFC_VERSION="1.2.6"
 
 # Class for holding different states so its clear what all valid states are
 class State(str, Enum):

--- a/extras/AFC_BoxTurtle.py
+++ b/extras/AFC_BoxTurtle.py
@@ -86,7 +86,7 @@ class afcBoxTurtle(afcUnit):
 
         if not cur_lane.prep_state:
             if not loaded:
-                self.afc.function.afc_led(cur_lane.led_not_ready, cur_lane.led_index)
+                cur_lane.unit_obj.lane_not_ready(cur_lane)
                 msg += 'EMPTY READY FOR SPOOL'
             else:
                 self.lane_fault(cur_lane)
@@ -605,7 +605,7 @@ class afcBoxTurtle(afcUnit):
             if x> self.MAX_NUM_MOVES:
                 msg = ' FAILED TO LOAD, CHECK FILAMENT AT TRIGGER\n||==>--||----||------||\nTRG   LOAD   HUB    TOOL'
                 self.afc.error.AFC_error(msg, False)
-                self.afc.function.afc_led(self.afc.led_fault, lane.led_index)
+                lane.unit_obj.lane_fault(lane)
                 lane.status = AFCLaneState.NONE
                 break
 

--- a/extras/AFC_OpenAMS.py
+++ b/extras/AFC_OpenAMS.py
@@ -1480,7 +1480,7 @@ class afcAMS(afcUnit):
             else:
                 if not cur_lane.remember_spool:
                     self.afc.spool.clear_values(cur_lane)
-                self.afc.function.afc_led(cur_lane.led_not_ready, cur_lane.led_index)
+                cur_lane.unit_obj.lane_not_ready(cur_lane)
                 msg += 'EMPTY READY FOR SPOOL'
 
         if assignTcmd:
@@ -2423,7 +2423,7 @@ class afcAMS(afcUnit):
                 pass
             del self._pending_spool_loaded_timers[lane.name]
         lane.loaded_to_hub = False
-        self.lane_unloaded(lane)
+        self.lane_not_ready(lane)
         spool_index = self._spool_map.get(lane.name)
         if spool_index is not None:
             hw = AMSHardwareService.for_printer(self.printer, self.oams_name, logger=self.logger)

--- a/extras/AFC_OpenAMS.py
+++ b/extras/AFC_OpenAMS.py
@@ -2296,7 +2296,7 @@ class afcAMS(afcUnit):
             f"Same-FPS infinite runout: {source_name} -> {target_name}")
 
         source_lane.status = AFCLaneState.NONE
-        self.lane_not_ready(source_lane)
+        self.lane_unloaded(source_lane)
 
         try:
             success = self._oams_load(target_lane)
@@ -2356,7 +2356,7 @@ class afcAMS(afcUnit):
 
         if not runout_lane_name:
             lane.status = AFCLaneState.NONE
-            self.lane_not_ready(lane)
+            self.lane_unloaded(lane)
             self.afc.error.AFC_error(
                 f"Runout detected on OAMS {lane.name}. "
                 f"No runout lane configured.\n"
@@ -2368,7 +2368,7 @@ class afcAMS(afcUnit):
         target_lane = self._resolve_lane_reference(runout_lane_name)
         if target_lane is None:
             lane.status = AFCLaneState.NONE
-            self.lane_not_ready(lane)
+            self.lane_unloaded(lane)
             self.afc.error.AFC_error(
                 f"Runout on OAMS {lane.name}: "
                 f"runout lane '{runout_lane_name}' not found",

--- a/extras/AFC_Toolchanger.py
+++ b/extras/AFC_Toolchanger.py
@@ -178,6 +178,8 @@ class AfcToolchanger(afcUnit):
         else:
             self.afc.gcode.run_script_from_command("UNSELECT_TOOL")
 
+        self.afc.function.handle_activate_extruder()
+
         lane_obj = self.afc.function.get_current_lane_obj()
         if lane_obj:
             if (lane_obj.prep_state

--- a/extras/AFC_error.py
+++ b/extras/AFC_error.py
@@ -371,7 +371,7 @@ class afcError:
         stack_name = caller_frame.f_code.co_name if caller_frame else ""
 
         self.AFC_error(msg, pause, stack_name=stack_name)
-        self.afc.function.afc_led(self.afc.led_fault, cur_lane.led_index)
+        cur_lane.unit_obj.lane_fault(cur_lane)
 
 def load_config(config: ConfigWrapper) -> afcError:
     """

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -604,7 +604,7 @@ class afcFunction:
                     else:
                         obj.unit_obj.lane_loaded(obj)
                 else:
-                    obj.unit_obj.lane_unloaded(obj)
+                    obj.unit_obj.lane_not_ready(obj)
 
         # Exit early if lane is None
         if cur_lane_loaded is None:

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -186,7 +186,7 @@ class AFCLane:
         self.led_spool_index      = config.get('led_spool_index', None)                 # LED index to illuminate under spool
         self.led_spool_illum      = config.get('led_spool_illuminate', None)            # LED color to illuminate under spool
         self.led_use_filament_color: bool = config.getboolean('led_use_filament_color', None)  # When True, uses filament color from color field for lane LEDs instead of configured LED colors
-        self.current_led_state: Optional[str] = ""
+        self.current_led_state: str = ""
 
         self.long_moves_speed: float   = config.getfloat("long_moves_speed", None)             # Speed in mm/s to move filament when doing long moves. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
         self.long_moves_accel: float   = config.getfloat("long_moves_accel", None)             # Acceleration in mm/s squared when doing long moves. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -186,6 +186,7 @@ class AFCLane:
         self.led_spool_index      = config.get('led_spool_index', None)                 # LED index to illuminate under spool
         self.led_spool_illum      = config.get('led_spool_illuminate', None)            # LED color to illuminate under spool
         self.led_use_filament_color: bool = config.getboolean('led_use_filament_color', None)  # When True, uses filament color from color field for lane LEDs instead of configured LED colors
+        self.current_led_state: Optional[str] = ""
 
         self.long_moves_speed: float   = config.getfloat("long_moves_speed", None)             # Speed in mm/s to move filament when doing long moves. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
         self.long_moves_accel: float   = config.getfloat("long_moves_accel", None)             # Acceleration in mm/s squared when doing long moves. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
@@ -1308,6 +1309,7 @@ class AFCLane:
 
                             # Record PREP activity (any lane) for handle_prep_runout's guard
                             self.afc.last_prep_activity_time = eventtime
+                            self.unit_obj.lane_loading(self)
 
                             # Calling common load function
                             self.unit_obj.prep_load(self)
@@ -1633,7 +1635,7 @@ class AFCLane:
         self.td1_data = {}
         if not self.remember_spool:
             self.afc.spool.clear_values(self)
-        self.unit_obj.lane_unloaded(self)
+        self.unit_obj.lane_not_ready(self)
 
     def set_tool_loaded(self, normal_toolchange: bool=False):
         """
@@ -2351,7 +2353,7 @@ class AFCLane:
         self.td1_data = {}
         if not self.remember_spool:
             self.afc.spool.clear_values(self)
-        self.unit_obj.lane_unloaded(self)
+        self.unit_obj.lane_not_ready(self)
         self.logger.info(f"{self.name} reset")
         self.afc.save_vars()
 

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -1032,7 +1032,6 @@ class AFCLane:
             - Once changeover is successful print is automatically resumed
         """
         self.status = AFCLaneState.NONE
-        self.unit_obj.lane_not_ready(self)
         self.logger.info("Infinite Spool triggered for {}".format(self.name))
         empty_lane = self.afc.lanes.get(self.afc.current)
 

--- a/extras/AFC_spool.py
+++ b/extras/AFC_spool.py
@@ -467,8 +467,7 @@ class AFCSpool:
         # Refresh LED only if filament is loaded — empty lanes keep their state color
         if (cur_lane.load_state
             and cur_lane.unit in self.afc.units):
-            unit = cur_lane.unit_obj
-            self.afc.function.afc_led(unit._get_lane_color(cur_lane, cur_lane.led_ready), cur_lane.led_index)
+            cur_lane.unit_obj.lane_loaded(cur_lane)
         self.afc.save_vars()
         self.set_snapmaker_filament_params(cur_lane)
 
@@ -736,8 +735,7 @@ class AFCSpool:
                     # Refresh LED only if filament is loaded — empty lanes keep their state color
                     if (cur_lane.load_state
                         and cur_lane.unit in self.afc.units):
-                        unit = cur_lane.unit_obj
-                        self.afc.function.afc_led(unit._get_lane_color(cur_lane, cur_lane.led_ready), cur_lane.led_index)
+                        cur_lane.unit_obj.lane_loaded(cur_lane)
 
                 except Exception as e:
                     self.afc.error.AFC_error(f"Error when trying to get Spoolman data for ID:{SpoolID}, Error: {e}", False)

--- a/extras/AFC_spool.py
+++ b/extras/AFC_spool.py
@@ -467,7 +467,7 @@ class AFCSpool:
         # Refresh LED only if filament is loaded — empty lanes keep their state color
         if (cur_lane.load_state
             and cur_lane.unit in self.afc.units):
-            cur_lane.unit_obj.lane_loaded(cur_lane)
+            cur_lane.unit_obj.lane_loaded(cur_lane,force=True)
         self.afc.save_vars()
         self.set_snapmaker_filament_params(cur_lane)
 
@@ -735,7 +735,7 @@ class AFCSpool:
                     # Refresh LED only if filament is loaded — empty lanes keep their state color
                     if (cur_lane.load_state
                         and cur_lane.unit in self.afc.units):
-                        cur_lane.unit_obj.lane_loaded(cur_lane)
+                        cur_lane.unit_obj.lane_loaded(cur_lane, force=True)
 
                 except Exception as e:
                     self.afc.error.AFC_error(f"Error when trying to get Spoolman data for ID:{SpoolID}, Error: {e}", False)

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -621,16 +621,22 @@ class afcUnit:
 
     def lane_not_ready(self, lane: AFCLane) -> None:
         """
-        Common function for setting a lanes led when a lane is not ready
+        Common function for setting a lanes led when a lane is not ready, aka filament not loaded
+        into a lane (prep and load both False). If a lane has an illumination led defined, its turned
+        off with this call.
 
         :param lane: Lane object to set led
         """
         if not self._check_led_state(lane, "not_ready"): return
         self._trigger_led_state(lane, static_color=lane.led_not_ready, effect_suffix="not_ready")
+        if lane.led_spool_index is not None:
+            self.afc.function.afc_led(self.afc.led_off, lane.led_spool_index)
 
     def lane_loaded(self, lane: AFCLane) -> None:
         """
-        Common function for setting a lanes led when lane is loaded
+        Common function for setting a lanes led when lane is loaded, normally this is called when
+        filament in lane is staged behind hub. If a lane has an illumination led defined, its turned
+        on with this call.
 
         :param lane: Lane object to set led
         """
@@ -643,7 +649,8 @@ class afcUnit:
 
     def lane_unloading(self, lane: AFCLane) -> None:
         """
-        Common function for setting a lanes led when lane is unloading
+        Common function for setting a lanes led when lane is unloading, this can be called when
+        unloading from toolhead and when ejecting a lane.
 
         :param lane: Lane object to set led
         """
@@ -652,18 +659,17 @@ class afcUnit:
 
     def lane_unloaded(self, lane: AFCLane) -> None:
         """
-        Common function for setting a lanes led when lane is unloaded
+        Common function for setting a lanes led when lane is unloaded but prep state is still True
 
         :param lane: Lane object to set led
         """
         if not self._check_led_state(lane, "unloaded"): return
         self._trigger_led_state(lane, static_color=lane.led_not_ready, effect_suffix="unloaded")
-        if lane.led_spool_index is not None:
-            self.afc.function.afc_led(self.afc.led_off, lane.led_spool_index)
 
     def lane_loading(self, lane: AFCLane) -> None:
         """
-        Common function for setting a lanes led when lane is loading
+        Common function for setting a lanes led when lane is loading, this can be called when
+        loading to toolhead or when loading spool into lane.
 
         :param lane: Lane object to set led
         """

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -632,15 +632,17 @@ class afcUnit:
         if lane.led_spool_index is not None:
             self.afc.function.afc_led(self.afc.led_off, lane.led_spool_index)
 
-    def lane_loaded(self, lane: AFCLane) -> None:
+    def lane_loaded(self, lane: AFCLane, force: bool=False) -> None:
         """
         Common function for setting a lanes led when lane is loaded, normally this is called when
         filament in lane is staged behind hub. If a lane has an illumination led defined, its turned
         on with this call.
 
         :param lane: Lane object to set led
+        :param force: Set True to re-apply the led even when the state is unchanged, used when
++            only the filament color changed
         """
-        if not self._check_led_state(lane, "loaded"): return
+        if not self._check_led_state(lane, "loaded") and not force: return
         color = self._get_lane_color(lane, lane.led_ready)
         self._trigger_led_state(lane, static_color=color, effect_suffix="loaded")
         # TODO: double check quattrobox led sets
@@ -719,7 +721,7 @@ class afcUnit:
         """
         if not self._check_led_state(lane, "tool_loaded_idle"): return
         color = self._get_lane_color(lane, lane.led_tool_loaded_idle)
-        # Extruder LED also shows filament color when tool is parked/idle —
+        # Extruder LED also shows filament color when tool is parked/idle,
         # gives a visual indicator of what's loaded. Reverts to config color
         # when tool becomes active (lane_tool_loaded) or unloads (lane_tool_unloaded).
         self._trigger_led_state(lane, static_color=color, extruder=lane.extruder_obj,

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -516,30 +516,57 @@ class afcUnit:
         # Clear out list once done disabling them all
         self.afc.active_led_effects = []
 
-    def _trigger_led_state(self, lane: AFCLane, static_color: str,
+    def _trigger_led_state(self, lane: Optional[AFCLane]=None,
+                           extruder: Optional[AFCExtruder]=None,
+                           static_color: Optional[str]=None,
+                           extruder_static_color: Optional[str]=None,
                            effect_suffix: Optional[str]=None) -> None:
         """
-        Method to apply led effects to leds, gcode is only called if
-        `led_effect <lane_name>_<effect_suffix>` is found in printer objects
+        Method to apply led effects to lane or extruder leds, gcode is only called if
+        `led_effect <lane_name/extruder_name>_<effect_suffix>` is found in printer objects
 
         :param lane: AFCLane to apply led effect to
+        :param extruder: AFCExtruder to apply led effect to
         :param static_color: Color to always apply to led
-        :param effect_suffix: Suffix to add to lane name for when calling SET_LED_EFFECT macro
+        :param effect_suffix: Suffix to add to lane/extruder name for when calling SET_LED_EFFECT macro
         """
         # Clear any running effects started by AFC
         self._stop_led_effects()
 
+        if (lane is None
+            and extruder is None):
+            return
+
         # Always apply the standard AFC static color first
         if static_color is not None:
-            self.afc.function.afc_led(static_color, lane.led_index)
+            if lane is not None:
+                self.afc.function.afc_led(static_color, lane.led_index)
+            if extruder is not None:
+                color = extruder_static_color if extruder_static_color is not None else static_color
+                extruder.set_status_led(color)
 
         # If an animation is requested, try to overlay it
         if effect_suffix:
-            effect_name = f"{lane.name}_{effect_suffix}"
+            lane_effect_name = ""
+            extruder_effect_name = ""
+            if lane is not None:
+                lane_effect_name = f"{lane.name}_{effect_suffix}"
+            if extruder is not None:
+                extruder_effect_name = f"{extruder.name}_{effect_suffix}"
+
             try:
-                if f"led_effect {effect_name}" in self.printer.objects:
-                    self.gcode.run_script_from_command(f"SET_LED_EFFECT EFFECT={effect_name}")
-                    self.afc.active_led_effects.append(effect_name)
+                if (lane_effect_name
+                    and f"led_effect {lane_effect_name}" in self.printer.objects):
+                    self.gcode.run_script_from_command(f"SET_LED_EFFECT EFFECT={lane_effect_name}")
+                    self.afc.active_led_effects.append(lane_effect_name)
+            except Exception:
+                pass
+
+            try:
+                if (extruder_effect_name
+                    and f"led_effect {extruder_effect_name}" in self.printer.objects):
+                    self.gcode.run_script_from_command(f"SET_LED_EFFECT EFFECT={extruder_effect_name}")
+                    self.afc.active_led_effects.append(extruder_effect_name)
             except Exception:
                 # If the effect doesn't exist, we just stay on the static color
                 pass
@@ -569,7 +596,7 @@ class afcUnit:
 
         :param lane: Lane object to set led
         """
-        self._trigger_led_state(lane, lane.led_not_ready, "not_ready")
+        self._trigger_led_state(lane, static_color=lane.led_not_ready, effect_suffix="not_ready")
 
     def lane_loaded(self, lane: AFCLane) -> None:
         """
@@ -578,7 +605,7 @@ class afcUnit:
         :param lane: Lane object to set led
         """
         color = self._get_lane_color(lane, lane.led_ready)
-        self._trigger_led_state(lane, color, "loaded")
+        self._trigger_led_state(lane, static_color=color, effect_suffix="loaded")
         # TODO: double check quattrobox led sets
         if lane.led_spool_index is not None:
             self.afc.function.afc_led(lane.led_spool_illum, lane.led_spool_index)
@@ -589,7 +616,7 @@ class afcUnit:
 
         :param lane: Lane object to set led
         """
-        self._trigger_led_state(lane, lane.led_unloading, "unloading")
+        self._trigger_led_state(lane, static_color=lane.led_unloading, effect_suffix="unloading")
 
     def lane_unloaded(self, lane: AFCLane) -> None:
         """
@@ -597,7 +624,7 @@ class afcUnit:
 
         :param lane: Lane object to set led
         """
-        self._trigger_led_state(lane, lane.led_not_ready, "unloaded")
+        self._trigger_led_state(lane, static_color=lane.led_not_ready, effect_suffix="unloaded")
         if lane.led_spool_index is not None:
             self.afc.function.afc_led(self.afc.led_off, lane.led_spool_index)
 
@@ -607,7 +634,7 @@ class afcUnit:
 
         :param lane: Lane object to set led
         """
-        self._trigger_led_state(lane, lane.led_loading, "loading")
+        self._trigger_led_state(lane, static_color=lane.led_loading, effect_suffix="loading")
 
     def lane_tool_loaded(self, lane: AFCLane) -> None:
         """
@@ -616,8 +643,8 @@ class afcUnit:
 
         :param lane: Lane object to set led
         """
-        self._trigger_led_state(lane, lane.led_tool_loaded, "tool_loaded")
-        lane.extruder_obj.set_status_led(lane.led_tool_loaded)
+        self._trigger_led_state(lane, lane.extruder_obj, static_color=lane.led_tool_loaded,
+                                effect_suffix="tool_loaded")
 
     def lane_tool_unloaded(self, lane: AFCLane) -> None:
         """
@@ -627,8 +654,9 @@ class afcUnit:
         :param lane: Lane object to set led
         """
         color = self._get_lane_color(lane, lane.led_ready)
-        self._trigger_led_state(lane, color, "tool_unloaded")
-        lane.extruder_obj.set_status_led(lane.led_tool_unloaded)
+        self._trigger_led_state(lane, lane.extruder_obj, static_color=color,
+                                extruder_static_color=lane.led_tool_unloaded,
+                                effect_suffix="tool_unloaded")
 
     def lane_tool_loaded_idle(self, lane: AFCLane) -> None:
         """
@@ -639,11 +667,11 @@ class afcUnit:
         :param lane: Lane object to set led
         """
         color = self._get_lane_color(lane, lane.led_tool_loaded_idle)
-        self._trigger_led_state(lane, color, "tool_loaded_idle")
         # Extruder LED also shows filament color when tool is parked/idle —
         # gives a visual indicator of what's loaded. Reverts to config color
         # when tool becomes active (lane_tool_loaded) or unloads (lane_tool_unloaded).
-        lane.extruder_obj.set_status_led(color)
+        self._trigger_led_state(lane, static_color=color, extruder=lane.extruder_obj,
+                                effect_suffix="tool_loaded_idle")
 
     def lane_illuminate_spool(self, lane: AFCLane) -> None:
         """
@@ -660,7 +688,7 @@ class afcUnit:
 
         :param lane: Lane object to set led
         """
-        self._trigger_led_state(lane, lane.led_fault, "fault")
+        self._trigger_led_state(lane, static_color=lane.led_fault, effect_suffix="fault")
 
     def select_lane( self, lane: AFCLane, sel_prep:bool=False ) -> tuple[bool, float|int]:
         """

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -507,12 +507,14 @@ class afcUnit:
         Iterates through active led effects that were successfully applied by AFC and disables
         them.
         """
-        try:
-            for effect in self.afc.active_led_effects:
+        for effect in self.afc.active_led_effects:
+            try:
                 script = f'SET_LED_EFFECT EFFECT={effect} STOP=1'
                 self.gcode.run_script_from_command(script)
-        except Exception:
-            pass
+            except Exception:
+                pass
+        # Clear out list once done disabling them all
+        self.afc.active_led_effects = []
 
     def _trigger_led_state(self, lane: AFCLane, static_color: str,
                            effect_suffix: Optional[str]=None) -> None:

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -502,19 +502,43 @@ class afcUnit:
             led_color = self.afc.function.HexToLedString(color.replace("#", ""))
             self.afc.function.afc_led( led_color, self.led_logo_index )
 
-    def _stop_led_effects(self) -> None:
+    def _stop_led_effects(self , targets: Optional[list[str]]=None) -> None:
         """
         Iterates through active led effects that were successfully applied by AFC and disables
-        them.
+        them. When targets is supplied, only effects whose prefix matches a target name are
+        stopped.
+
+        :param targets: List of names(lane or extruder) to stop
         """
+        remaining = []
         for effect in self.afc.active_led_effects:
+            if (targets is not None
+                and not any(effect.startswith(f"{t}_") for t in targets)):
+                remaining.append(effect)
+                continue
             try:
                 script = f'SET_LED_EFFECT EFFECT={effect} STOP=1'
                 self.gcode.run_script_from_command(script)
             except Exception:
                 pass
-        # Clear out list once done disabling them all
-        self.afc.active_led_effects = []
+
+        self.afc.active_led_effects = remaining
+
+    def _call_led_effect(self, name: str, effect_suffix: str) -> None:
+        """
+        Common method of calling SET_LED_EFFECT with effect name, method constructs effect name as
+        <name>_<effect_suffix>, only called if the correct led_effects object exists.
+
+        :param name: Prefix name to add to effect_suffix, eg. lane/extruder name
+        :param effect_suffix: Effect name to apply, eg. loading, unloading, etc.
+        """
+        try:
+            effect_name = f"{name}_{effect_suffix}"
+            if f"led_effect {effect_name}" in self.printer.objects:
+                self.gcode.run_script_from_command(f"SET_LED_EFFECT EFFECT={effect_name}")
+                self.afc.active_led_effects.append(effect_name)
+        except Exception:
+            pass
 
     def _trigger_led_state(self, lane: Optional[AFCLane]=None,
                            extruder: Optional[AFCExtruder]=None,
@@ -528,14 +552,21 @@ class afcUnit:
         :param lane: AFCLane to apply led effect to
         :param extruder: AFCExtruder to apply led effect to
         :param static_color: Color to always apply to led
+        :param extruder_static_color: Extruder color to apply to extruder led, if `extruder` is
+            passed in a this is not set, then extruder led defaults to `static_color` variable
         :param effect_suffix: Suffix to add to lane/extruder name for when calling SET_LED_EFFECT macro
         """
-        # Clear any running effects started by AFC
-        self._stop_led_effects()
-
         if (lane is None
             and extruder is None):
             return
+        names_to_stop = []
+        if lane is not None:
+            names_to_stop.append(lane.name)
+        if extruder is not None:
+            names_to_stop.append(extruder.name)
+
+        # Clear running effects started by AFC
+        self._stop_led_effects(names_to_stop)
 
         # Always apply the standard AFC static color first
         if static_color is not None:
@@ -547,29 +578,11 @@ class afcUnit:
 
         # If an animation is requested, try to overlay it
         if effect_suffix:
-            lane_effect_name = ""
-            extruder_effect_name = ""
             if lane is not None:
-                lane_effect_name = f"{lane.name}_{effect_suffix}"
+                self._call_led_effect(lane.name, effect_suffix)
+
             if extruder is not None:
-                extruder_effect_name = f"{extruder.name}_{effect_suffix}"
-
-            try:
-                if (lane_effect_name
-                    and f"led_effect {lane_effect_name}" in self.printer.objects):
-                    self.gcode.run_script_from_command(f"SET_LED_EFFECT EFFECT={lane_effect_name}")
-                    self.afc.active_led_effects.append(lane_effect_name)
-            except Exception:
-                pass
-
-            try:
-                if (extruder_effect_name
-                    and f"led_effect {extruder_effect_name}" in self.printer.objects):
-                    self.gcode.run_script_from_command(f"SET_LED_EFFECT EFFECT={extruder_effect_name}")
-                    self.afc.active_led_effects.append(extruder_effect_name)
-            except Exception:
-                # If the effect doesn't exist, we just stay on the static color
-                pass
+                self._call_led_effect(extruder.name, effect_suffix)
 
     def _get_lane_color(self, lane: AFCLane, fallback: str) -> str:
         """

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -492,7 +492,7 @@ class afcUnit:
         prompt.create_custom_p(title, text, None,
                                True, buttons, back)
 
-    def set_logo_color(self, color: str) -> None:
+    def set_logo_color(self, color: Optional[str]=None) -> None:
         """
         Common function for setting a units logo led's
 
@@ -640,7 +640,7 @@ class afcUnit:
 
         :param lane: Lane object to set led
         :param force: Set True to re-apply the led even when the state is unchanged, used when
-+            only the filament color changed
+            only the filament color changed
         """
         if not self._check_led_state(lane, "loaded") and not force: return
         color = self._get_lane_color(lane, lane.led_ready)

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -603,12 +603,29 @@ class afcUnit:
                 return self.afc.function.HexToLedString(hex_str)
         return fallback
 
+    def _check_led_state(self, lane: AFCLane, state: str) -> bool:
+        """
+        Checks if led state is already set for specified lane. If the pass in state is not set, then
+        lanes `current_led_state` is set to the passed in state.
+
+        :param lane: AFCLane to check state against
+        :param state: Led state to compare and change internal variable to
+        :return bool: Return false if current led state matches passed in state. Returns True if
+            led state does not match passed in state.
+        """
+        if lane.current_led_state == state:
+            return False
+        else:
+            lane.current_led_state = state
+            return True
+
     def lane_not_ready(self, lane: AFCLane) -> None:
         """
         Common function for setting a lanes led when a lane is not ready
 
         :param lane: Lane object to set led
         """
+        if not self._check_led_state(lane, "not_ready"): return
         self._trigger_led_state(lane, static_color=lane.led_not_ready, effect_suffix="not_ready")
 
     def lane_loaded(self, lane: AFCLane) -> None:
@@ -617,6 +634,7 @@ class afcUnit:
 
         :param lane: Lane object to set led
         """
+        if not self._check_led_state(lane, "loaded"): return
         color = self._get_lane_color(lane, lane.led_ready)
         self._trigger_led_state(lane, static_color=color, effect_suffix="loaded")
         # TODO: double check quattrobox led sets
@@ -629,6 +647,7 @@ class afcUnit:
 
         :param lane: Lane object to set led
         """
+        if not self._check_led_state(lane, "unloading"): return
         self._trigger_led_state(lane, static_color=lane.led_unloading, effect_suffix="unloading")
 
     def lane_unloaded(self, lane: AFCLane) -> None:
@@ -637,6 +656,7 @@ class afcUnit:
 
         :param lane: Lane object to set led
         """
+        if not self._check_led_state(lane, "unloaded"): return
         self._trigger_led_state(lane, static_color=lane.led_not_ready, effect_suffix="unloaded")
         if lane.led_spool_index is not None:
             self.afc.function.afc_led(self.afc.led_off, lane.led_spool_index)
@@ -647,7 +667,17 @@ class afcUnit:
 
         :param lane: Lane object to set led
         """
+        if not self._check_led_state(lane, "loading"): return
         self._trigger_led_state(lane, static_color=lane.led_loading, effect_suffix="loading")
+
+    def lane_tool_loaded_gears(self, lane: AFCLane) -> None:
+        """
+        Common function for setting a lanes led when lane is loaded before the toolhead gears
+
+        :param lane: Lane object to set led
+        """
+        if not self._check_led_state(lane, "tool_loaded_gears"): return
+        self._trigger_led_state(lane, lane.extruder_obj, effect_suffix="tool_loaded_gears")
 
     def lane_tool_loaded(self, lane: AFCLane) -> None:
         """
@@ -656,6 +686,7 @@ class afcUnit:
 
         :param lane: Lane object to set led
         """
+        if not self._check_led_state(lane, "tool_loaded"): return
         self._trigger_led_state(lane, lane.extruder_obj, static_color=lane.led_tool_loaded,
                                 effect_suffix="tool_loaded")
 
@@ -666,6 +697,7 @@ class afcUnit:
 
         :param lane: Lane object to set led
         """
+        if not self._check_led_state(lane, "tool_unloaded"): return
         color = self._get_lane_color(lane, lane.led_ready)
         self._trigger_led_state(lane, lane.extruder_obj, static_color=color,
                                 extruder_static_color=lane.led_tool_unloaded,
@@ -679,6 +711,7 @@ class afcUnit:
 
         :param lane: Lane object to set led
         """
+        if not self._check_led_state(lane, "tool_loaded_idle"): return
         color = self._get_lane_color(lane, lane.led_tool_loaded_idle)
         # Extruder LED also shows filament color when tool is parked/idle —
         # gives a visual indicator of what's loaded. Reverts to config color
@@ -701,6 +734,7 @@ class afcUnit:
 
         :param lane: Lane object to set led
         """
+        if not self._check_led_state(lane, "fault"): return
         self._trigger_led_state(lane, static_color=lane.led_fault, effect_suffix="fault")
 
     def select_lane( self, lane: AFCLane, sel_prep:bool=False ) -> tuple[bool, float|int]:

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -492,7 +492,7 @@ class afcUnit:
         prompt.create_custom_p(title, text, None,
                                True, buttons, back)
 
-    def set_logo_color(self, color):
+    def set_logo_color(self, color: str) -> None:
         """
         Common function for setting a units logo led's
 
@@ -502,13 +502,45 @@ class afcUnit:
             led_color = self.afc.function.HexToLedString(color.replace("#", ""))
             self.afc.function.afc_led( led_color, self.led_logo_index )
 
-    def lane_not_ready(self, lane):
+    def _stop_led_effects(self) -> None:
         """
-        Common function for setting a lanes led when a lane is not ready
+        Iterates through active led effects that were successfully applied by AFC and disables
+        them.
+        """
+        try:
+            for effect in self.afc.active_led_effects:
+                script = f'SET_LED_EFFECT EFFECT={effect} STOP=1'
+                self.gcode.run_script_from_command(script)
+        except Exception:
+            pass
 
-        :param lane: Lane object to set led
+    def _trigger_led_state(self, lane: AFCLane, static_color: str,
+                           effect_suffix: Optional[str]=None) -> None:
         """
-        self.afc.function.afc_led(lane.led_not_ready, lane.led_index)
+        Method to apply led effects to leds, gcode is only called if
+        `led_effect <lane_name>_<effect_suffix>` is found in printer objects
+
+        :param lane: AFCLane to apply led effect to
+        :param static_color: Color to always apply to led
+        :param effect_suffix: Suffix to add to lane name for when calling SET_LED_EFFECT macro
+        """
+        # Clear any running effects started by AFC
+        self._stop_led_effects()
+
+        # Always apply the standard AFC static color first
+        if static_color is not None:
+            self.afc.function.afc_led(static_color, lane.led_index)
+
+        # If an animation is requested, try to overlay it
+        if effect_suffix:
+            effect_name = f"{lane.name}_{effect_suffix}"
+            try:
+                if f"led_effect {effect_name}" in self.printer.objects:
+                    self.gcode.run_script_from_command(f"SET_LED_EFFECT EFFECT={effect_name}")
+                    self.afc.active_led_effects.append(effect_name)
+            except Exception:
+                # If the effect doesn't exist, we just stay on the static color
+                pass
 
     def _get_lane_color(self, lane: AFCLane, fallback: str) -> str:
         """
@@ -523,69 +555,80 @@ class afcUnit:
         :return: LED color value (list of floats or config color string)
         """
         if lane.led_use_filament_color and lane.color:
+            # TODO: add ability to display TD color instead of users inputted color
             hex_str = lane.color.replace("#", "").strip().upper()
             if len(hex_str) in (6, 8) and all(c in "0123456789ABCDEF" for c in hex_str):
                 return self.afc.function.HexToLedString(hex_str)
         return fallback
 
-    def lane_loaded(self, lane: AFCLane):
+    def lane_not_ready(self, lane: AFCLane) -> None:
+        """
+        Common function for setting a lanes led when a lane is not ready
+
+        :param lane: Lane object to set led
+        """
+        self._trigger_led_state(lane, lane.led_not_ready, "not_ready")
+
+    def lane_loaded(self, lane: AFCLane) -> None:
         """
         Common function for setting a lanes led when lane is loaded
 
         :param lane: Lane object to set led
         """
-        self.afc.function.afc_led(self._get_lane_color(lane, lane.led_ready), lane.led_index)
+        color = self._get_lane_color(lane, lane.led_ready)
+        self._trigger_led_state(lane, color, "loaded")
         # TODO: double check quattrobox led sets
         if lane.led_spool_index is not None:
             self.afc.function.afc_led(lane.led_spool_illum, lane.led_spool_index)
 
-    def lane_unloading(self, lane):
+    def lane_unloading(self, lane: AFCLane) -> None:
         """
         Common function for setting a lanes led when lane is unloading
 
         :param lane: Lane object to set led
         """
-        self.afc.function.afc_led(lane.led_unloading, lane.led_index)
+        self._trigger_led_state(lane, lane.led_unloading, "unloading")
 
-    def lane_unloaded(self, lane: AFCLane):
+    def lane_unloaded(self, lane: AFCLane) -> None:
         """
         Common function for setting a lanes led when lane is unloaded
 
         :param lane: Lane object to set led
         """
-        self.lane_not_ready(lane)
+        self._trigger_led_state(lane, lane.led_not_ready, "unloaded")
         if lane.led_spool_index is not None:
             self.afc.function.afc_led(self.afc.led_off, lane.led_spool_index)
 
-    def lane_loading(self, lane: AFCLane):
+    def lane_loading(self, lane: AFCLane) -> None:
         """
         Common function for setting a lanes led when lane is loading
 
         :param lane: Lane object to set led
         """
-        self.afc.function.afc_led(lane.led_loading, lane.led_index)
+        self._trigger_led_state(lane, lane.led_loading, "loading")
 
-    def lane_tool_loaded(self, lane: AFCLane):
+    def lane_tool_loaded(self, lane: AFCLane) -> None:
         """
         Common function for setting a lanes led when lane is tool loaded,
         also sets toolheads led status color
 
         :param lane: Lane object to set led
         """
-        self.afc.function.afc_led(lane.led_tool_loaded, lane.led_index)
+        self._trigger_led_state(lane, lane.led_tool_loaded, "tool_loaded")
         lane.extruder_obj.set_status_led(lane.led_tool_loaded)
 
-    def lane_tool_unloaded(self, lane: AFCLane):
+    def lane_tool_unloaded(self, lane: AFCLane) -> None:
         """
         Common function for setting a lanes led when lane is tool unloaded,
         also sets toolheads led status color
 
         :param lane: Lane object to set led
         """
-        self.afc.function.afc_led(self._get_lane_color(lane, lane.led_ready), lane.led_index)
+        color = self._get_lane_color(lane, lane.led_ready)
+        self._trigger_led_state(lane, color, "tool_unloaded")
         lane.extruder_obj.set_status_led(lane.led_tool_unloaded)
 
-    def lane_tool_loaded_idle(self, lane):
+    def lane_tool_loaded_idle(self, lane: AFCLane) -> None:
         """
         Common function for setting a lanes led when its loaded into a tool
         and tool is docked(for toolchangers). Function also sets toolheads led
@@ -594,13 +637,13 @@ class afcUnit:
         :param lane: Lane object to set led
         """
         color = self._get_lane_color(lane, lane.led_tool_loaded_idle)
-        self.afc.function.afc_led(color, lane.led_index)
+        self._trigger_led_state(lane, color, "tool_loaded_idle")
         # Extruder LED also shows filament color when tool is parked/idle —
         # gives a visual indicator of what's loaded. Reverts to config color
         # when tool becomes active (lane_tool_loaded) or unloads (lane_tool_unloaded).
         lane.extruder_obj.set_status_led(color)
 
-    def lane_illuminate_spool(self, lane):
+    def lane_illuminate_spool(self, lane: AFCLane) -> None:
         """
         Common function for setting lane illumination leds
 
@@ -609,13 +652,13 @@ class afcUnit:
         if lane.led_spool_index is not None:
             self.afc.function.afc_led(lane.led_spool_illum, lane.led_spool_index)
 
-    def lane_fault(self, lane):
+    def lane_fault(self, lane: AFCLane) -> None:
         """
         Common function for setting a lanes led when a fault happens
 
         :param lane: Lane object to set led
         """
-        self.afc.function.afc_led(lane.led_fault, lane.led_index)
+        self._trigger_led_state(lane, lane.led_fault, "fault")
 
     def select_lane( self, lane: AFCLane, sel_prep:bool=False ) -> tuple[bool, float|int]:
         """

--- a/extras/AFC_vivid.py
+++ b/extras/AFC_vivid.py
@@ -333,7 +333,7 @@ class AFC_vivid(afcBoxTurtle):
         cur_lane.loaded_to_hub = False
         cur_lane.status = AFCLaneState.NONE
         cur_lane.calibrated_lane = False
-        self.afc.function.afc_led(cur_lane.led_not_ready, cur_lane.led_index)
+        cur_lane.unit_obj.lane_not_ready(cur_lane)
         return True, "calibration_lane", 0
 
     def calibration_lane_message(self) -> str:

--- a/extras/AFC_vivid.py
+++ b/extras/AFC_vivid.py
@@ -333,7 +333,7 @@ class AFC_vivid(afcBoxTurtle):
         cur_lane.loaded_to_hub = False
         cur_lane.status = AFCLaneState.NONE
         cur_lane.calibrated_lane = False
-        cur_lane.unit_obj.lane_not_ready(cur_lane)
+        cur_lane.unit_obj.lane_unloaded(cur_lane)
         return True, "calibration_lane", 0
 
     def calibration_lane_message(self) -> str:

--- a/templates/led_effects_examples.cfg
+++ b/templates/led_effects_examples.cfg
@@ -1,0 +1,96 @@
+# ── Filament actively feeding into the lane. Rainbow gradient sweeps in the ──
+# "incoming" pin direction so the motion itself reads as "loading."
+[led_effect lane1_loading]
+autostart: false
+frame_rate: 24
+leds: AFC_led:AFC_Indicator2 (9,10,11,12,13,14,15,16)
+layers:
+    # All RGB values reduced by 50% (e.g., 1.0 -> 0.5)
+    gradient 1.0 1.0 add (0.5,0.0,0.0),(0.5,0.25,0.0),(0.5,0.5,0.0),(0.0,0.5,0.0),(0.0,0.0,0.5),(0.15,0.0,0.25)
+
+# ── Filament backing out of the lane. Same gradient as lane1_loading, but ───
+# the pin order is reversed so the sweep visually travels the other way.
+[led_effect lane1_unloading]
+autostart: false
+frame_rate: 24
+leds: AFC_led:AFC_Indicator2 (16,15,14,13,12,11,10,9)
+layers:
+    gradient 1.0 1.0 add (0.5,0.0,0.0),(0.5,0.25,0.0),(0.5,0.5,0.0),(0.0,0.5,0.0),(0.0,0.0,0.5),(0.15,0.0,0.25)
+
+# ── Lane needs attention (jam, sensor mismatch, failed load/unload, etc). ───
+# Fast red blink -- the most urgent-looking state, distinct from the slower
+# red breathe on lane1_not_ready/lane1_unloaded below.
+[led_effect lane1_fault]
+autostart: false
+frame_rate: 24
+leds: AFC_led:AFC_Indicator2 (16,15,14,13,12,11,10,9)
+layers:
+    blink 1.0 0.5 top (1.0,0.0,0.0)
+
+# ── Empty lane, nothing staged. Slow red breathe -- gentler than fault's ────
+# fast blink, but still flags the lane as needing attention.
+[led_effect lane1_not_ready]
+autostart: false
+frame_rate: 24
+leds: AFC_led:AFC_Indicator2 (9,10,11,12,13,14,15,16)
+layers:
+    breathing 2.5 0 top (1.0,0.0,0.0)
+
+# ── Filament staged and confirmed ready. Same slow breathe as not_ready, ────
+# just in the "good" color so ready vs. empty is obvious at a glance.
+[led_effect lane1_loaded]
+autostart: false
+frame_rate: 24
+leds: AFC_led:AFC_Indicator2 (9,10,11,12,13,14,15,16)
+layers:
+    breathing 2.5 0 top (0.0,0.5,0.0)
+
+# ── Just unloaded from the lane. A quick decaying flash for feedback before ─
+# the LED settles back into lane1_not_ready.
+[led_effect lane1_unloaded]
+autostart: false
+frame_rate: 24
+leds: AFC_led:AFC_Indicator2 (9,10,11,12,13,14,15,16)
+layers:
+    strobe 2.0 3.0 add (1.0,0.0,0.0)
+
+# ── Lane is the active/loaded tool right now (fires on any tool change, ─────
+# not just mid-print, so it can't depend on print-progress data). Two chase
+# layers with opposite rates, blended with "add" so both stay visible as they
+# cross -- the closest thing to "back and forth" the effect plugin supports;
+# it doesn't have true bounce/ping-pong on a single layer.
+[led_effect lane1_tool_loaded]
+autostart: false
+frame_rate: 24
+leds: AFC_led:AFC_Indicator2 (9,10,11,12,13,14,15,16)
+layers:
+    chase 1.5 2 add (0.0,0.3,0.5),(0.0,0.15,0.25)
+    chase -1.5 2 add (0.0,0.3,0.5),(0.0,0.15,0.25)
+
+# ── Alternate tool_loaded look, same blue as lane1_tool_loaded above but a ───
+# twinkle instead of a chase -- a calmer option for units where the chase's
+# motion is too busy (e.g. visible gear-driven mechanisms).
+[led_effect lane1_tool_loaded_gears]
+autostart: false
+frame_rate: 24
+leds: AFC_led:AFC_Indicator2 (9,10,11,12,13,14,15,16)
+layers:
+    twinkle 1 .75 top (0.0,0.3,0.5),(0.0,0.15,0.25)
+
+# ── Tool just unloaded from the toolhead. Sparse purple sparkle reads as ────
+# the tool's presence dissipating, no directionality needed.
+[led_effect lane1_tool_unloaded]
+autostart: false
+frame_rate: 24
+leds: AFC_led:AFC_Indicator2 (16,15,14,13,12,11,10,9)
+layers:
+    twinkle 1 .75 top (0.5,0.0,0.5),(0.25,0.0,0.25)
+
+# ── Tool loaded but idle (parked between tool changes). Slower breathe than ─
+# lane1_loaded so "actively the tool" vs. "just staged" feel distinct.
+[led_effect lane1_tool_loaded_idle]
+autostart: false
+frame_rate: 24
+leds: AFC_led:AFC_Indicator2 (9,10,11,12,13,14,15,16)
+layers:
+    breathing 4.0 0 top (0.4,0.4,0,0)

--- a/templates/led_effects_examples.cfg
+++ b/templates/led_effects_examples.cfg
@@ -1,5 +1,6 @@
-# ── Filament actively feeding into the lane. Rainbow gradient sweeps in the ──
-# "incoming" pin direction so the motion itself reads as "loading."
+# Filament actively feeding into the lane (loading to the toolhead, or loading
+# a spool into the lane itself). Rainbow gradient sweeps in the "incoming" pin
+# direction so the motion itself reads as "loading."
 [led_effect lane1_loading]
 autostart: false
 frame_rate: 24
@@ -8,8 +9,9 @@ layers:
     # All RGB values reduced by 50% (e.g., 1.0 -> 0.5)
     gradient 1.0 1.0 add (0.5,0.0,0.0),(0.5,0.25,0.0),(0.5,0.5,0.0),(0.0,0.5,0.0),(0.0,0.0,0.5),(0.15,0.0,0.25)
 
-# ── Filament backing out of the lane. Same gradient as lane1_loading, but ───
-# the pin order is reversed so the sweep visually travels the other way.
+# Filament backing out of the lane (unloading from the toolhead, or ejecting
+# the lane). Same gradient as lane1_loading, but the pin order is reversed so
+# the sweep visually travels the other way.
 [led_effect lane1_unloading]
 autostart: false
 frame_rate: 24
@@ -17,9 +19,10 @@ leds: AFC_led:AFC_Indicator2 (16,15,14,13,12,11,10,9)
 layers:
     gradient 1.0 1.0 add (0.5,0.0,0.0),(0.5,0.25,0.0),(0.5,0.5,0.0),(0.0,0.5,0.0),(0.0,0.0,0.5),(0.15,0.0,0.25)
 
-# ── Lane needs attention (jam, sensor mismatch, failed load/unload, etc). ───
-# Fast red blink -- the most urgent-looking state, distinct from the slower
-# red breathe on lane1_not_ready/lane1_unloaded below.
+# Lane needs attention (jam, sensor mismatch, failed load/unload, etc). Fast
+# red blink, the most urgent-looking state, distinct from the slower red
+# breathe on lane1_not_ready/lane1_unloaded below. Lane-only, this state does
+# not apply to the extruder's LEDs.
 [led_effect lane1_fault]
 autostart: false
 frame_rate: 24
@@ -27,8 +30,9 @@ leds: AFC_led:AFC_Indicator2 (16,15,14,13,12,11,10,9)
 layers:
     blink 1.0 0.5 top (1.0,0.0,0.0)
 
-# ── Empty lane, nothing staged. Slow red breathe -- gentler than fault's ────
-# fast blink, but still flags the lane as needing attention.
+# Lane completely empty, no spool prepped (prep and load sensors both False).
+# Slow red breathe, gentler than fault's fast blink, but still flags the lane as
+# needing attention. Lane-only, this state does not apply to the extruder's LEDs.
 [led_effect lane1_not_ready]
 autostart: false
 frame_rate: 24
@@ -36,8 +40,9 @@ leds: AFC_led:AFC_Indicator2 (9,10,11,12,13,14,15,16)
 layers:
     breathing 2.5 0 top (1.0,0.0,0.0)
 
-# ── Filament staged and confirmed ready. Same slow breathe as not_ready, ────
-# just in the "good" color so ready vs. empty is obvious at a glance.
+# Filament staged and confirmed ready, behind the hub. Same slow breathe as
+# not_ready, just in the "good" color so ready vs. empty is obvious at a
+# glance. Lane-only, this state does not apply to the extruder's LEDs.
 [led_effect lane1_loaded]
 autostart: false
 frame_rate: 24
@@ -45,8 +50,10 @@ leds: AFC_led:AFC_Indicator2 (9,10,11,12,13,14,15,16)
 layers:
     breathing 2.5 0 top (0.0,0.5,0.0)
 
-# ── Just unloaded from the lane. A quick decaying flash for feedback before ─
-# the LED settles back into lane1_not_ready.
+# Lane no longer loaded, but a spool is still prepped (prep sensor still True,
+# unlike lane1_not_ready above where prep is False too). A quick decaying
+# flash for feedback before the LED settles back into whichever state follows.
+# Lane-only, this state does not apply to the extruder's LEDs.
 [led_effect lane1_unloaded]
 autostart: false
 frame_rate: 24
@@ -54,11 +61,19 @@ leds: AFC_led:AFC_Indicator2 (9,10,11,12,13,14,15,16)
 layers:
     strobe 2.0 3.0 add (1.0,0.0,0.0)
 
-# ── Lane is the active/loaded tool right now (fires on any tool change, ─────
-# not just mid-print, so it can't depend on print-progress data). Two chase
-# layers with opposite rates, blended with "add" so both stay visible as they
-# cross -- the closest thing to "back and forth" the effect plugin supports;
-# it doesn't have true bounce/ping-pong on a single layer.
+# States below also apply to the extruder's own LEDs.
+# tool_loaded_gears, tool_loaded, tool_unloaded, and tool_loaded_idle each fire
+# on both the lane and its extruder, so every one of them gets a matching
+# `<extruder_name>_<state>` effect too (named "extruder" here for a single
+# toolhead setup, adjust to match your own [AFC_extruder] section name). Each
+# extruder example below reuses the exact same effect so lane and extruder
+# read as one connected animation; point them at a different LED chain/colors
+# if you'd rather the toolhead read independently from the lane.
+
+# Lane is the active/loaded tool right now (fires on any tool change). Two
+# chase layers with opposite rates, blended with "add" so both stay visible as
+# they cross; the closest thing to "back and forth" the effect plugin
+# supports, since it doesn't have true bounce/ping-pong on a single layer.
 [led_effect lane1_tool_loaded]
 autostart: false
 frame_rate: 24
@@ -67,28 +82,67 @@ layers:
     chase 1.5 2 add (0.0,0.3,0.5),(0.0,0.15,0.25)
     chase -1.5 2 add (0.0,0.3,0.5),(0.0,0.15,0.25)
 
-# ── Alternate tool_loaded look, same blue as lane1_tool_loaded above but a ───
-# twinkle instead of a chase -- a calmer option for units where the chase's
-# motion is too busy (e.g. visible gear-driven mechanisms).
+# Extruder counterpart of lane1_tool_loaded above, fires at the same time.
+[led_effect extruder_tool_loaded]
+autostart: false
+frame_rate: 24
+leds: AFC_led:AFC_Indicator2 (9,10,11,12,13,14,15,16)
+layers:
+    chase 1.5 2 add (0.0,0.3,0.5),(0.0,0.15,0.25)
+    chase -1.5 2 add (0.0,0.3,0.5),(0.0,0.15,0.25)
+
+# Filament has reached the toolhead gears, part-way through the load, before
+# lane1_tool_loaded fires. Same blue as lane1_tool_loaded, but a fast twinkle
+# instead of a chase, so this intermediate step reads as distinct from the
+# completed load.
 [led_effect lane1_tool_loaded_gears]
 autostart: false
 frame_rate: 24
 leds: AFC_led:AFC_Indicator2 (9,10,11,12,13,14,15,16)
 layers:
-    twinkle 1 .75 top (0.0,0.3,0.5),(0.0,0.15,0.25)
+    twinkle 5 .5 top (0.0,0.3,0.5),(0.0,0.15,0.25)
 
-# ── Tool just unloaded from the toolhead. Sparse purple sparkle reads as ────
-# the tool's presence dissipating, no directionality needed.
+# Extruder counterpart of lane1_tool_loaded_gears above, fires at the same time.
+[led_effect extruder_tool_loaded_gears]
+autostart: false
+frame_rate: 24
+leds: AFC_led:AFC_Indicator2 (9,10,11,12,13,14,15,16)
+layers:
+    twinkle 5 .5 top (0.0,0.3,0.5),(0.0,0.15,0.25)
+
+# Tool just unloaded from the toolhead. Fast sparse purple sparkle reads as
+# the tool's presence dissipating, no directionality needed. The extruder LED
+# can use its own separate static color for this state (see the
+# extruder_static_color note on _trigger_led_state), but the effect overlay
+# itself is the same one shown here.
 [led_effect lane1_tool_unloaded]
 autostart: false
 frame_rate: 24
 leds: AFC_led:AFC_Indicator2 (16,15,14,13,12,11,10,9)
 layers:
-    twinkle 1 .75 top (0.5,0.0,0.5),(0.25,0.0,0.25)
+    twinkle 5 .5 top (0.5,0.0,0.5),(0.25,0.0,0.25)
 
-# ── Tool loaded but idle (parked between tool changes). Slower breathe than ─
-# lane1_loaded so "actively the tool" vs. "just staged" feel distinct.
+# Extruder counterpart of lane1_tool_unloaded above, fires at the same time.
+[led_effect extruder_tool_unloaded]
+autostart: false
+frame_rate: 24
+leds: AFC_led:AFC_Indicator2 (16,15,14,13,12,11,10,9)
+layers:
+    twinkle 5 .5 top (0.5,0.0,0.5),(0.25,0.0,0.25)
+
+# Tool loaded but idle (parked between tool changes, e.g. on a toolchanger).
+# Slower breathe than lane1_loaded so "actively the tool" vs. "just staged"
+# feel distinct. The extruder LED shows the same filament color as the lane
+# while idle.
 [led_effect lane1_tool_loaded_idle]
+autostart: false
+frame_rate: 24
+leds: AFC_led:AFC_Indicator2 (9,10,11,12,13,14,15,16)
+layers:
+    breathing 4.0 0 top (0.4,0.4,0,0)
+
+# Extruder counterpart of lane1_tool_loaded_idle above, fires at the same time.
+[led_effect extruder_tool_loaded_idle]
 autostart: false
 frame_rate: 24
 leds: AFC_led:AFC_Indicator2 (9,10,11,12,13,14,15,16)

--- a/templates/led_effects_examples.cfg
+++ b/templates/led_effects_examples.cfg
@@ -1,10 +1,14 @@
+# These are all examples. The `leds` line and the LED index range/count on
+# each `layers` line need to be updated to match your own LED chain name and
+# length before use, they will not work as-is with a different setup.
+
 # Filament actively feeding into the lane (loading to the toolhead, or loading
 # a spool into the lane itself). Rainbow gradient sweeps in the "incoming" pin
 # direction so the motion itself reads as "loading."
 [led_effect lane1_loading]
 autostart: false
 frame_rate: 24
-leds: AFC_led:AFC_Indicator2 (9,10,11,12,13,14,15,16)
+leds: AFC_led:AFC_Indicator (9,10,11,12,13,14,15,16)
 layers:
     # All RGB values reduced by 50% (e.g., 1.0 -> 0.5)
     gradient 1.0 1.0 add (0.5,0.0,0.0),(0.5,0.25,0.0),(0.5,0.5,0.0),(0.0,0.5,0.0),(0.0,0.0,0.5),(0.15,0.0,0.25)
@@ -15,7 +19,7 @@ layers:
 [led_effect lane1_unloading]
 autostart: false
 frame_rate: 24
-leds: AFC_led:AFC_Indicator2 (16,15,14,13,12,11,10,9)
+leds: AFC_led:AFC_Indicator (16,15,14,13,12,11,10,9)
 layers:
     gradient 1.0 1.0 add (0.5,0.0,0.0),(0.5,0.25,0.0),(0.5,0.5,0.0),(0.0,0.5,0.0),(0.0,0.0,0.5),(0.15,0.0,0.25)
 
@@ -26,7 +30,7 @@ layers:
 [led_effect lane1_fault]
 autostart: false
 frame_rate: 24
-leds: AFC_led:AFC_Indicator2 (16,15,14,13,12,11,10,9)
+leds: AFC_led:AFC_Indicator (16,15,14,13,12,11,10,9)
 layers:
     blink 1.0 0.5 top (1.0,0.0,0.0)
 
@@ -36,7 +40,7 @@ layers:
 [led_effect lane1_not_ready]
 autostart: false
 frame_rate: 24
-leds: AFC_led:AFC_Indicator2 (9,10,11,12,13,14,15,16)
+leds: AFC_led:AFC_Indicator (9,10,11,12,13,14,15,16)
 layers:
     breathing 2.5 0 top (1.0,0.0,0.0)
 
@@ -46,7 +50,7 @@ layers:
 [led_effect lane1_loaded]
 autostart: false
 frame_rate: 24
-leds: AFC_led:AFC_Indicator2 (9,10,11,12,13,14,15,16)
+leds: AFC_led:AFC_Indicator (9,10,11,12,13,14,15,16)
 layers:
     breathing 2.5 0 top (0.0,0.5,0.0)
 
@@ -57,7 +61,7 @@ layers:
 [led_effect lane1_unloaded]
 autostart: false
 frame_rate: 24
-leds: AFC_led:AFC_Indicator2 (9,10,11,12,13,14,15,16)
+leds: AFC_led:AFC_Indicator (9,10,11,12,13,14,15,16)
 layers:
     strobe 2.0 3.0 add (1.0,0.0,0.0)
 
@@ -77,7 +81,7 @@ layers:
 [led_effect lane1_tool_loaded]
 autostart: false
 frame_rate: 24
-leds: AFC_led:AFC_Indicator2 (9,10,11,12,13,14,15,16)
+leds: AFC_led:AFC_Indicator (9,10,11,12,13,14,15,16)
 layers:
     chase 1.5 2 add (0.0,0.3,0.5),(0.0,0.15,0.25)
     chase -1.5 2 add (0.0,0.3,0.5),(0.0,0.15,0.25)
@@ -86,7 +90,7 @@ layers:
 [led_effect extruder_tool_loaded]
 autostart: false
 frame_rate: 24
-leds: AFC_led:AFC_Indicator2 (9,10,11,12,13,14,15,16)
+leds: AFC_led:AFC_Indicator (9,10,11,12,13,14,15,16)
 layers:
     chase 1.5 2 add (0.0,0.3,0.5),(0.0,0.15,0.25)
     chase -1.5 2 add (0.0,0.3,0.5),(0.0,0.15,0.25)
@@ -98,7 +102,7 @@ layers:
 [led_effect lane1_tool_loaded_gears]
 autostart: false
 frame_rate: 24
-leds: AFC_led:AFC_Indicator2 (9,10,11,12,13,14,15,16)
+leds: AFC_led:AFC_Indicator (9,10,11,12,13,14,15,16)
 layers:
     twinkle 5 .5 top (0.0,0.3,0.5),(0.0,0.15,0.25)
 
@@ -106,7 +110,7 @@ layers:
 [led_effect extruder_tool_loaded_gears]
 autostart: false
 frame_rate: 24
-leds: AFC_led:AFC_Indicator2 (9,10,11,12,13,14,15,16)
+leds: AFC_led:AFC_Indicator (9,10,11,12,13,14,15,16)
 layers:
     twinkle 5 .5 top (0.0,0.3,0.5),(0.0,0.15,0.25)
 
@@ -118,7 +122,7 @@ layers:
 [led_effect lane1_tool_unloaded]
 autostart: false
 frame_rate: 24
-leds: AFC_led:AFC_Indicator2 (16,15,14,13,12,11,10,9)
+leds: AFC_led:AFC_Indicator (16,15,14,13,12,11,10,9)
 layers:
     twinkle 5 .5 top (0.5,0.0,0.5),(0.25,0.0,0.25)
 
@@ -126,7 +130,7 @@ layers:
 [led_effect extruder_tool_unloaded]
 autostart: false
 frame_rate: 24
-leds: AFC_led:AFC_Indicator2 (16,15,14,13,12,11,10,9)
+leds: AFC_led:AFC_Indicator (16,15,14,13,12,11,10,9)
 layers:
     twinkle 5 .5 top (0.5,0.0,0.5),(0.25,0.0,0.25)
 
@@ -137,7 +141,7 @@ layers:
 [led_effect lane1_tool_loaded_idle]
 autostart: false
 frame_rate: 24
-leds: AFC_led:AFC_Indicator2 (9,10,11,12,13,14,15,16)
+leds: AFC_led:AFC_Indicator (9,10,11,12,13,14,15,16)
 layers:
     breathing 4.0 0 top (0.4,0.4,0,0)
 
@@ -145,6 +149,6 @@ layers:
 [led_effect extruder_tool_loaded_idle]
 autostart: false
 frame_rate: 24
-leds: AFC_led:AFC_Indicator2 (9,10,11,12,13,14,15,16)
+leds: AFC_led:AFC_Indicator (9,10,11,12,13,14,15,16)
 layers:
     breathing 4.0 0 top (0.4,0.4,0,0)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -520,7 +520,7 @@ class MockAFC:
         self.enable_runout_in_bypass = False
         self.show_macros = True
         self.message_queue: list = []
-        self.active_led_effects: list = []
+        self.active_led_effects: list[str] = []
         self.log_frame_data = True
         self.position_saved = False
         self.in_toolchange = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -520,6 +520,7 @@ class MockAFC:
         self.enable_runout_in_bypass = False
         self.show_macros = True
         self.message_queue: list = []
+        self.active_led_effects: list = []
         self.log_frame_data = True
         self.position_saved = False
         self.in_toolchange = False

--- a/tests/test_AFC.py
+++ b/tests/test_AFC.py
@@ -168,6 +168,7 @@ def _make_afc():
     obj.print_data_metadata = None
     obj.disable_print_temp_check = False
     obj.enable_multiple_mapping = False
+    obj.active_led_effects = []
     return obj
 
 
@@ -252,7 +253,7 @@ class TestGetStatus:
         required = {
             "current_load", "current_state", "error_state",
             "lanes", "extruders", "hubs", "buffers", "units",
-            "message", "position_saved", "multiple_tool_mapping"
+            "message", "position_saved", "multiple_tool_mapping",
         }
         for key in required:
             assert key in status, f"Missing key: {key}"
@@ -3516,6 +3517,55 @@ class TestDoPoopKickWipe:
 
 
 
+class TestLoadSequenceDefaultPathSuccess:
+    """Covers the default (no unit_load_lane hook) hub/toolhead move path in
+    load_sequence all the way to its finalize step, distinct from
+    test_no_unit_load_lane_hook_falls_through_to_default_path which returns
+    early via a homing-error branch and never reaches finalization."""
+
+    def _make(self):
+        afc = _make_afc()
+        afc._check_extruder_temp = MagicMock(return_value=False)
+        afc.save_vars = MagicMock()
+        afc.homing_enabled = True
+        afc.gcode_move = MagicMock()
+        afc.gcode_move.last_position = [0.0, 0.0, 0.0, 0.0]
+        lane = _make_afc_lane()
+        lane.custom_load_cmd = None
+        lane.unit_obj = MagicMock(spec=["load_then_home", "lane_tool_loaded_gears", "lane_tool_loaded"])
+        lane.hub_obj = None
+        lane.loaded_to_hub = False
+        lane.is_direct_hub = MagicMock(return_value=True)
+        lane.unit_obj.load_then_home.return_value = (None, None, AFCMoveWarning.NONE)
+        lane.get_toolhead_pre_sensor_state = MagicMock(return_value=True)
+        lane.sync_to_extruder = MagicMock()
+        lane.spool_id = None
+        lane.enable_buffer = MagicMock()
+        hub = MagicMock()
+        extruder = MagicMock()
+        extruder.tool_end = False  # skip the post-load tool_end-sensor retry loop
+        return afc, lane, hub, extruder
+
+    def test_sync_to_extruder_called(self):
+        afc, lane, hub, extruder = self._make()
+        afc.load_sequence(lane, hub, extruder)
+        lane.sync_to_extruder.assert_called_once_with()
+
+    def test_status_set_to_tool_loaded(self):
+        """status passes through TOOL_LOADED right after sync_to_extruder,
+        then set_tool_loaded() (called later in the same sequence) advances
+        it to TOOLED -- asserting the final state here."""
+        afc, lane, hub, extruder = self._make()
+        afc.load_sequence(lane, hub, extruder)
+        assert lane.status == AFCLaneState.TOOLED
+
+    def test_lane_tool_loaded_gears_called(self):
+        afc, lane, hub, extruder = self._make()
+        afc.load_sequence(lane, hub, extruder)
+        assert not hasattr(lane.unit_obj, "unit_load_lane")
+        lane.unit_obj.lane_tool_loaded_gears.assert_called_once_with(lane)
+
+
 class TestToolLoadNeedPurge:
     def _make_afc_lane_for_need_purge(self, need_purge=True, check_extruder_temp_return=True,
                                       printing=False):
@@ -3546,7 +3596,7 @@ class TestToolLoadNeedPurge:
 
         afc.capture_toolhead_temp.assert_not_called()
         afc.restore_toolhead_temp.assert_not_called()
-        afc.save_vars.assert_not_called()        
+        afc.save_vars.assert_not_called()
 
     def test_need_purge_no_purge_length(self):
         afc, lane = self._make_afc_lane_for_need_purge()
@@ -3964,6 +4014,42 @@ class TestUnloadSequenceUnitUnloadLane:
         lane.select_lane.assert_called_once_with()
         afc.error.handle_lane_failure.assert_called_once()
 
+    def test_default_path_success_calls_lane_loaded_not_lane_tool_unloaded(self):
+        """Covers the default toolhead-retract path all the way through to
+        finalization, distinct from the early-failure variant above. Also
+        locks in that this now calls lane_loaded (not the old lane_tool_unloaded)
+        once the lane is safely back at the hub."""
+        afc, lane, hub, extruder = self._make()
+        lane.unit_obj = MagicMock(
+            spec=["lane_unloading", "move_to_hub", "lane_loaded", "return_to_home"])
+        afc.tool_cut = False
+        afc.form_tip = False
+        afc.move_e_pos = MagicMock()
+        afc.homing_enabled = False
+        lane.disable_buffer = MagicMock()
+        lane.sync_to_extruder = MagicMock()
+        lane.unsync_to_extruder = MagicMock()
+        lane.select_lane = MagicMock()
+        lane.move_advanced = MagicMock()
+        lane.set_tool_unloaded = MagicMock()
+        lane.tool_max_unload_attempts = 5
+        lane.get_toolhead_pre_sensor_state.return_value = False
+        lane.is_direct_hub = MagicMock(return_value=False)
+        lane.unit_obj.move_to_hub.return_value = (None, None, AFCMoveWarning.NONE)
+        extruder.tool_start = ""
+        extruder.tool_stn_unload = 0
+        extruder.tool_end_state = False
+        extruder.tool_sensor_after_extruder = 0
+        hub.state = False
+        hub.cut = False
+
+        result = afc.unload_sequence(lane, hub, extruder)
+
+        assert result is not False
+        lane.unit_obj.lane_loaded.assert_called_once_with(lane)
+        assert lane.status == AFCLaneState.NONE
+        assert lane.loaded_to_hub is True
+
 
 # ── unload_sequence: custom_unload_cmd path runs post_unload_macro ─────────────
 # New branch inside the (pre-existing) custom_unload_cmd path: a configured
@@ -4247,7 +4333,8 @@ class TestLaneUnload:
         obj.LANE_UNLOAD(cur_lane)
         obj.spool.set_spoolID.assert_called_once_with(cur_lane, None)
         cur_lane.unit_obj.return_to_home.assert_called_once()
-        cur_lane.unit_obj.lane_not_ready.assert_called_once_with(cur_lane)
+        cur_lane.unit_obj.lane_unloading.assert_called_once_with(cur_lane)
+        cur_lane.unit_obj.lane_unloaded.assert_called_once_with(cur_lane)
 
     def test_eject_logs_completion_only(self):
         obj, cur_lane = _make_afc_for_lane_unload(lane_loaded="lane2", standalone=False)

--- a/tests/test_AFC_BoxTurtle.py
+++ b/tests/test_AFC_BoxTurtle.py
@@ -45,6 +45,7 @@ def _make_box_turtle(name="Turtle_1"):
     unit.td1_defined = False
     unit.type = "Box_Turtle"
     unit.gcode = afc.gcode
+    unit.short_move_dis = 10
 
     return unit
 
@@ -81,11 +82,11 @@ class TestConstants:
 
 class TestSystemTestEmptyLane:
     def test_empty_lane_sets_not_ready_led(self):
-        """prep=False, load=False → LED set to led_not_ready."""
+        """prep=False, load=False → lane's own unit_obj.lane_not_ready is called."""
         unit = _make_box_turtle()
         lane = _make_lane(prep_state=False, load_state=False)
         unit.system_Test(lane, delay=0.0, assignTcmd=True, enable_movement=False)
-        unit.afc.function.afc_led.assert_any_call(lane.led_not_ready, lane.led_index)
+        lane.unit_obj.lane_not_ready.assert_called_once_with(lane)
 
     def test_empty_lane_does_not_set_fault_led(self):
         unit = _make_box_turtle()
@@ -187,6 +188,71 @@ class Test_MoveLane:
             result = unit._move_lane(lane, delay=1, enable_movement=True)
         assert result is False
         pause_mock.assert_called()
+
+
+# ── prep_load ────────────────────────────────────────────────────────────────
+
+class TestPrepLoad:
+    def _make_lane_that_never_triggers(self):
+        """A lane that stays prepped but never reports load-sensor triggered,
+        so prep_load's retry loop always keeps going until MAX_NUM_MOVES."""
+        lane = _make_afc_lane()
+        lane.prep_state = True
+        lane.load = "PA1"
+        lane._load_state = False
+        lane.move = MagicMock()
+        lane.unit_obj = MagicMock()
+        return lane
+
+    def test_exceeding_max_num_moves_calls_lane_fault(self):
+        unit = _make_box_turtle()
+        unit.afc.homing_enabled = False
+        lane = self._make_lane_that_never_triggers()
+
+        unit.prep_load(lane)
+
+        lane.unit_obj.lane_fault.assert_called_once_with(lane)
+
+    def test_exceeding_max_num_moves_resets_status_to_none(self):
+        from extras.AFC_lane import AFCLaneState
+        unit = _make_box_turtle()
+        unit.afc.homing_enabled = False
+        lane = self._make_lane_that_never_triggers()
+
+        unit.prep_load(lane)
+
+        assert lane.status == AFCLaneState.NONE
+
+    def test_exceeding_max_num_moves_reports_afc_error(self):
+        unit = _make_box_turtle()
+        unit.afc.homing_enabled = False
+        lane = self._make_lane_that_never_triggers()
+
+        unit.prep_load(lane)
+
+        msg = unit.afc.error.AFC_error.call_args[0][0]
+        assert "FAILED TO LOAD" in msg
+
+    def test_sensor_triggering_before_max_moves_skips_fault(self):
+        """Covers the `x > MAX_NUM_MOVES` guard's False branch: the loop
+        exits normally (via raw_load_state going True) without faulting."""
+        unit = _make_box_turtle()
+        unit.afc.homing_enabled = False
+        lane = _make_afc_lane()
+        lane.prep_state = True
+        lane.load = "PA1"
+        lane._load_state = False
+        lane.unit_obj = MagicMock()
+
+        def _trigger_after_one_move(*args, **kwargs):
+            lane._load_state = True
+
+        lane.move = MagicMock(side_effect=_trigger_after_one_move)
+
+        unit.prep_load(lane)
+
+        lane.unit_obj.lane_fault.assert_not_called()
+        unit.afc.error.AFC_error.assert_not_called()
 
 
 class TestCalibrateBowdenNegativeDistance:

--- a/tests/test_AFC_OpenAMS.py
+++ b/tests/test_AFC_OpenAMS.py
@@ -2893,7 +2893,7 @@ class TestHandleSameFpsReload:
     def test_success_switches_active_lane(self):
         ams, afc, printer, reactor = _make_ams()
         ams._oams_load = MagicMock(return_value=True)
-        ams.lane_not_ready = MagicMock()
+        ams.lane_unloaded = MagicMock()
         ams.lane_tool_loaded = MagicMock()
         ams.gcode = MagicMock()
         source = _make_lane("lane1", map=None)
@@ -2903,7 +2903,7 @@ class TestHandleSameFpsReload:
 
         assert result is True
         assert source.status == AFCLaneState.NONE
-        ams.lane_not_ready.assert_called_once_with(source)
+        ams.lane_unloaded.assert_called_once_with(source)
         target.set_tool_loaded.assert_called_once()
         ams.lane_tool_loaded.assert_called_once_with(target)
         afc.save_vars.assert_called_once()
@@ -2917,7 +2917,7 @@ class TestHandleSameFpsReload:
     def test_swaps_mapping_via_afc_swap_mapping_when_source_map_present(self):
         ams, afc, printer, reactor = _make_ams()
         ams._oams_load = MagicMock(return_value=True)
-        ams.lane_not_ready = MagicMock()
+        ams.lane_unloaded = MagicMock()
         ams.lane_tool_loaded = MagicMock()
         ams.gcode = MagicMock()
         source = _make_lane("lane1", map="T0")
@@ -2933,7 +2933,7 @@ class TestHandleSameFpsReload:
         the source lane currently has a map assigned."""
         ams, afc, printer, reactor = _make_ams()
         ams._oams_load = MagicMock(return_value=True)
-        ams.lane_not_ready = MagicMock()
+        ams.lane_unloaded = MagicMock()
         ams.lane_tool_loaded = MagicMock()
         ams.gcode = MagicMock()
         source = _make_lane("lane1", map=None)
@@ -2947,7 +2947,7 @@ class TestHandleSameFpsReload:
     def test_hardware_load_failure_pauses_and_returns_false(self):
         ams, afc, printer, reactor = _make_ams()
         ams._oams_load = MagicMock(return_value=False)
-        ams.lane_not_ready = MagicMock()
+        ams.lane_unloaded = MagicMock()
         source = _make_lane("lane1")
         target = _make_lane("lane2")
 
@@ -2964,7 +2964,7 @@ class TestHandleSameFpsReload:
     def test_hardware_load_exception_pauses_and_returns_false(self):
         ams, afc, printer, reactor = _make_ams()
         ams._oams_load = MagicMock(side_effect=Exception("mcu fault"))
-        ams.lane_not_ready = MagicMock()
+        ams.lane_unloaded = MagicMock()
         source = _make_lane("lane1")
         target = _make_lane("lane2")
 
@@ -2981,27 +2981,27 @@ class TestHandleSameFpsReload:
 class TestHandleRunout:
     def test_no_runout_lane_configured_pauses(self):
         ams, afc, printer, reactor = _make_ams()
-        ams.lane_not_ready = MagicMock()
+        ams.lane_unloaded = MagicMock()
         lane = _make_lane("lane1", runout_lane=None)
 
         result = ams.handle_runout(lane)
 
         assert result is True
         assert lane.status == AFCLaneState.NONE
-        ams.lane_not_ready.assert_called_once_with(lane)
+        ams.lane_unloaded.assert_called_once_with(lane)
         afc.error.AFC_error.assert_called_once()
         assert afc.error.AFC_error.call_args[1]["pause"] is True
 
     def test_runout_lane_not_found_pauses(self):
         ams, afc, printer, reactor = _make_ams()
-        ams.lane_not_ready = MagicMock()
+        ams.lane_unloaded = MagicMock()
         ams._resolve_lane_reference = MagicMock(return_value=None)
         lane = _make_lane("lane1", runout_lane="missing_lane")
 
         result = ams.handle_runout(lane)
 
         assert result is True
-        ams.lane_not_ready.assert_called_once_with(lane)
+        ams.lane_unloaded.assert_called_once_with(lane)
         afc.error.AFC_error.assert_called_once()
 
     def test_same_extruder_triggers_seamless_reload(self):

--- a/tests/test_AFC_OpenAMS.py
+++ b/tests/test_AFC_OpenAMS.py
@@ -4574,17 +4574,17 @@ class TestOnFilamentInsert:
 class TestOnFilamentRemove:
     def test_clears_loaded_to_hub_and_unloads(self):
         ams, afc, printer, reactor = _make_ams()
-        ams.lane_unloaded = MagicMock()
+        ams.lane_not_ready = MagicMock()
         ams._clear_lane_info = MagicMock()
         ams._clear_oams_state_for_bay = MagicMock()
         lane = _make_lane("lane1", loaded_to_hub=True, tool_loaded=False)
         ams.on_filament_remove(lane)
         assert lane.loaded_to_hub is False
-        ams.lane_unloaded.assert_called_once_with(lane)
+        ams.lane_not_ready.assert_called_once_with(lane)
 
     def test_cancels_pending_spool_loaded_timer(self):
         ams, afc, printer, reactor = _make_ams()
-        ams.lane_unloaded = MagicMock()
+        ams.lane_not_ready = MagicMock()
         ams._clear_lane_info = MagicMock()
         ams._clear_oams_state_for_bay = MagicMock()
         timer = MagicMock()
@@ -4597,7 +4597,7 @@ class TestOnFilamentRemove:
 
     def test_timer_unregister_failure_is_swallowed(self):
         ams, afc, printer, reactor = _make_ams()
-        ams.lane_unloaded = MagicMock()
+        ams.lane_not_ready = MagicMock()
         ams._clear_lane_info = MagicMock()
         ams._clear_oams_state_for_bay = MagicMock()
         reactor.unregister_timer = MagicMock(side_effect=Exception("boom"))
@@ -4608,7 +4608,7 @@ class TestOnFilamentRemove:
 
     def test_clears_lane_info_when_not_tool_loaded(self):
         ams, afc, printer, reactor = _make_ams()
-        ams.lane_unloaded = MagicMock()
+        ams.lane_not_ready = MagicMock()
         ams._clear_lane_info = MagicMock()
         ams._clear_oams_state_for_bay = MagicMock()
         lane = _make_lane("lane1", tool_loaded=False)
@@ -4618,7 +4618,7 @@ class TestOnFilamentRemove:
 
     def test_skips_clear_lane_info_when_tool_loaded_runout(self):
         ams, afc, printer, reactor = _make_ams()
-        ams.lane_unloaded = MagicMock()
+        ams.lane_not_ready = MagicMock()
         ams._clear_lane_info = MagicMock()
         ams._clear_oams_state_for_bay = MagicMock()
         lane = _make_lane("lane1", tool_loaded=True)
@@ -4628,7 +4628,7 @@ class TestOnFilamentRemove:
 
     def test_updates_hardware_snapshot_when_mapped(self):
         ams, afc, printer, reactor = _make_ams()
-        ams.lane_unloaded = MagicMock()
+        ams.lane_not_ready = MagicMock()
         ams._clear_lane_info = MagicMock()
         ams._clear_oams_state_for_bay = MagicMock()
         ams._spool_map["lane1"] = 0
@@ -6658,7 +6658,7 @@ class TestSystemTest:
         assert result is True
         afc.spool.clear_values.assert_called_once_with(lane)
         ams.lane_loaded.assert_not_called()
-        afc.function.afc_led.assert_called_once_with(lane.led_not_ready, lane.led_index)
+        lane.unit_obj.lane_not_ready.assert_called_once_with(lane)
         assert any(
             lvl == "info" and m.startswith("lane1 tool cmd: T0 ")
             for lvl, m in ams.logger.messages)

--- a/tests/test_AFC_QuattroBox.py
+++ b/tests/test_AFC_QuattroBox.py
@@ -99,11 +99,24 @@ class TestLaneLoaded:
 # ── lane_unloaded ─────────────────────────────────────────────────────────────
 
 class TestLaneUnloaded:
-    def test_calls_led_off_for_spool(self):
-        """lane_unloaded should turn off spool LEDs."""
+    def test_does_not_touch_spool_led(self):
+        """lane_unloaded no longer manages the spool illumination LED --
+        that responsibility moved to lane_not_ready."""
         unit = _make_quattro()
         lane = _make_lane()
         unit.lane_unloaded(lane)
+        for c in unit.afc.function.afc_led.call_args_list:
+            assert c[0][0] != unit.afc.led_off
+
+
+# ── lane_not_ready ────────────────────────────────────────────────────────────
+
+class TestLaneNotReady:
+    def test_calls_led_off_for_spool(self):
+        """lane_not_ready should turn off spool LEDs."""
+        unit = _make_quattro()
+        lane = _make_lane()
+        unit.lane_not_ready(lane)
         unit.afc.function.afc_led.assert_any_call(unit.afc.led_off, lane.led_spool_index)
 
 

--- a/tests/test_AFC_Toolchanger.py
+++ b/tests/test_AFC_Toolchanger.py
@@ -350,6 +350,15 @@ class TestCmdAFCUnselectTool:
 
         extruder.estats.tool_unselected.increase_count.assert_called_once()
 
+    def test_calls_handle_activate_extruder(self):
+        extruder = _make_extruder_obj()
+        tool = _make_toolchanger_for_unselect(current_extruder=extruder)
+        gcmd = _build_gcmd()
+
+        tool.cmd_AFC_UNSELECT_TOOL(gcmd)
+
+        tool.afc.function.handle_activate_extruder.assert_called_once_with()
+
     def test_current_state_goes_tool_dock_during_unselect_then_idle(self):
         extruder = _make_extruder_obj()
         extruder.custom_unselect = None

--- a/tests/test_AFC_error.py
+++ b/tests/test_AFC_error.py
@@ -319,6 +319,14 @@ class TestHandleLaneFailure:
         err.handle_lane_failure(cur_lane, "jammed", pause=False)
         assert cur_lane.status == AFCLaneState.ERROR
 
+    def test_calls_lane_fault(self):
+        err, afc = _make_afc_error()
+        err.AFC_error = MagicMock()
+        cur_lane = MagicMock()
+        cur_lane.name = "lane1"
+        err.handle_lane_failure(cur_lane, "jammed", pause=False)
+        cur_lane.unit_obj.lane_fault.assert_called_once_with(cur_lane)
+
     def test_calls_afc_error_with_lane_name_in_message(self):
         err, afc = _make_afc_error()
         err.AFC_error = MagicMock()

--- a/tests/test_AFC_functions.py
+++ b/tests/test_AFC_functions.py
@@ -1646,3 +1646,92 @@ class TestCmdAfcLaneResetToolheadLoadedGuard:
         func.afc.error.AFC_error.assert_not_called()
         lane.unit_obj.move_to_hub.assert_called_once()
         func.afc.gcode.respond_info.assert_any_call("Resetting lane1 to hub")
+
+
+# ── handle_activate_extruder / _handle_activate_extruder ─────────────────────
+
+class TestHandleActivateExtruder:
+    def _make(self, cur_lane_loaded=None):
+        func = _make_func()
+        func.get_current_lane_obj = MagicMock(return_value=cur_lane_loaded)
+        func.afc.spool = MagicMock()
+        return func
+
+    def _make_other_lane(self, name="lane2", prep_state=False, load_state=False,
+                         tool_loaded=False):
+        lane = _make_afc_lane(f"AFC_stepper {name}")
+        lane.do_enable = MagicMock()
+        lane.disable_buffer = MagicMock()
+        lane.unsync_to_extruder = MagicMock()
+        lane.prep_state = prep_state
+        lane._load_state = load_state
+        lane.tool_loaded = tool_loaded
+        lane.unit_obj = MagicMock()
+        return lane
+
+    def test_handle_activate_extruder_delegates_to_underscore_variant(self):
+        func = self._make()
+        func._handle_activate_extruder = MagicMock()
+        func.handle_activate_extruder()
+        func._handle_activate_extruder.assert_called_once_with(0)
+
+    def test_not_ready_lane_calls_lane_not_ready(self):
+        """Covers the `prep_state and load_state` guard's False branch --
+        this now calls lane_not_ready (not the old lane_unloaded)."""
+        func = self._make(cur_lane_loaded=None)
+        lane = self._make_other_lane(prep_state=False, load_state=False)
+        func.afc.lanes = {"lane2": lane}
+        func._handle_activate_extruder(0)
+        lane.unit_obj.lane_not_ready.assert_called_once_with(lane)
+        lane.unit_obj.lane_loaded.assert_not_called()
+        lane.unit_obj.lane_tool_loaded_idle.assert_not_called()
+
+    def test_ready_prep_only_calls_lane_not_ready(self):
+        """prep_state alone must not satisfy the guard."""
+        func = self._make(cur_lane_loaded=None)
+        lane = self._make_other_lane(prep_state=True, load_state=False)
+        func.afc.lanes = {"lane2": lane}
+        func._handle_activate_extruder(0)
+        lane.unit_obj.lane_not_ready.assert_called_once_with(lane)
+
+    def test_ready_load_only_calls_lane_not_ready(self):
+        """load_state alone must not satisfy the guard."""
+        func = self._make(cur_lane_loaded=None)
+        lane = self._make_other_lane(prep_state=False, load_state=True)
+        func.afc.lanes = {"lane2": lane}
+        func._handle_activate_extruder(0)
+        lane.unit_obj.lane_not_ready.assert_called_once_with(lane)
+
+    def test_ready_not_tool_loaded_calls_lane_loaded(self):
+        func = self._make(cur_lane_loaded=None)
+        lane = self._make_other_lane(prep_state=True, load_state=True, tool_loaded=False)
+        func.afc.lanes = {"lane2": lane}
+        func._handle_activate_extruder(0)
+        lane.unit_obj.lane_loaded.assert_called_once_with(lane)
+        lane.unit_obj.lane_not_ready.assert_not_called()
+
+    def test_ready_and_tool_loaded_calls_lane_tool_loaded_idle(self):
+        func = self._make(cur_lane_loaded=None)
+        lane = self._make_other_lane(prep_state=True, load_state=True, tool_loaded=True)
+        func.afc.lanes = {"lane2": lane}
+        func._handle_activate_extruder(0)
+        lane.unit_obj.lane_tool_loaded_idle.assert_called_once_with(lane)
+        lane.unit_obj.lane_loaded.assert_not_called()
+        lane.unit_obj.lane_not_ready.assert_not_called()
+
+    def test_active_lane_is_skipped_entirely(self):
+        """The currently-loaded lane must not be touched by this loop at all."""
+        func = self._make()
+        active_lane = self._make_other_lane("lane1", prep_state=True, load_state=True)
+        active_lane.enable_buffer = MagicMock()
+        active_lane.sync_to_extruder = MagicMock()
+        active_lane.spool_id = None
+        func.get_current_lane_obj = MagicMock(return_value=active_lane)
+        func.afc.lanes = {"lane1": active_lane}
+        func._handle_activate_extruder(0)
+        # do_enable(True) is legitimately called later, outside the loop, to
+        # enable the active lane -- do_enable(False) is what the (skipped)
+        # loop body would have called, so that's the call that must be absent.
+        active_lane.do_enable.assert_called_once_with(True)
+        active_lane.unit_obj.lane_not_ready.assert_not_called()
+        active_lane.unit_obj.lane_loaded.assert_not_called()

--- a/tests/test_AFC_lane.py
+++ b/tests/test_AFC_lane.py
@@ -2334,8 +2334,136 @@ def _make_lane_for_set_loaded(
     lane.unit_obj.select_lane = MagicMock()
  
     return lane
- 
- 
+
+
+# ── set_loaded / set_unloaded ──────────────────────────────────────────────
+
+class TestSetLoaded:
+    def test_status_set_to_loaded(self):
+        lane = _make_afc_lane()
+        lane.set_loaded()
+        assert lane.status == AFCLaneState.LOADED
+
+    def test_calls_lane_loaded(self):
+        lane = _make_afc_lane()
+        lane.set_loaded()
+        lane.unit_obj.lane_loaded.assert_called_once_with(lane)
+
+    def test_calls_spool_set_values(self):
+        lane = _make_afc_lane()
+        lane.set_loaded()
+        lane.afc.spool._set_values.assert_called_once_with(lane)
+
+
+class TestSetUnloaded:
+    def _make_lane(self, remember_spool=False):
+        lane = _make_afc_lane()
+        lane.tool_loaded = True
+        lane.status = AFCLaneState.TOOLED
+        lane.loaded_to_hub = True
+        lane.td1_data = {"scan_time": "1.0"}
+        lane.remember_spool = remember_spool
+        return lane
+
+    def test_tool_loaded_cleared(self):
+        lane = self._make_lane()
+        lane.set_unloaded()
+        assert lane.tool_loaded is False
+
+    def test_status_set_to_none(self):
+        lane = self._make_lane()
+        lane.set_unloaded()
+        assert lane.status == AFCLaneState.NONE
+
+    def test_loaded_to_hub_cleared(self):
+        lane = self._make_lane()
+        lane.set_unloaded()
+        assert lane.loaded_to_hub is False
+
+    def test_td1_data_cleared(self):
+        lane = self._make_lane()
+        lane.set_unloaded()
+        assert lane.td1_data == {}
+
+    def test_clears_spool_values_when_not_remembering(self):
+        lane = self._make_lane(remember_spool=False)
+        lane.set_unloaded()
+        lane.afc.spool.clear_values.assert_called_once_with(lane)
+
+    def test_does_not_clear_spool_values_when_remembering(self):
+        """Covers the `not self.remember_spool` guard's False branch."""
+        lane = self._make_lane(remember_spool=True)
+        lane.set_unloaded()
+        lane.afc.spool.clear_values.assert_not_called()
+
+    def test_calls_lane_not_ready(self):
+        """set_unloaded now marks the lane not_ready (not the old
+        lane_unloaded), so a freshly-emptied lane and one that was never
+        loaded end up in the same LED state."""
+        lane = self._make_lane()
+        lane.set_unloaded()
+        lane.unit_obj.lane_not_ready.assert_called_once_with(lane)
+
+
+# ── cmd_AFC_RECOVER_LANE ───────────────────────────────────────────────────
+
+class TestCmdAfcRecoverLane:
+    def _make_lane(self, remember_spool=False):
+        lane = _make_afc_lane()
+        lane.tool_loaded = True
+        lane.status = AFCLaneState.TOOLED
+        lane.loaded_to_hub = True
+        lane.td1_data = {"scan_time": "1.0"}
+        lane.remember_spool = remember_spool
+        return lane
+
+    def test_tool_loaded_cleared(self):
+        lane = self._make_lane()
+        lane.cmd_AFC_RECOVER_LANE(MagicMock())
+        assert lane.tool_loaded is False
+
+    def test_status_set_to_none(self):
+        lane = self._make_lane()
+        lane.cmd_AFC_RECOVER_LANE(MagicMock())
+        assert lane.status == AFCLaneState.NONE
+
+    def test_loaded_to_hub_cleared(self):
+        lane = self._make_lane()
+        lane.cmd_AFC_RECOVER_LANE(MagicMock())
+        assert lane.loaded_to_hub is False
+
+    def test_td1_data_cleared(self):
+        lane = self._make_lane()
+        lane.cmd_AFC_RECOVER_LANE(MagicMock())
+        assert lane.td1_data == {}
+
+    def test_clears_spool_values_when_not_remembering(self):
+        lane = self._make_lane(remember_spool=False)
+        lane.cmd_AFC_RECOVER_LANE(MagicMock())
+        lane.afc.spool.clear_values.assert_called_once_with(lane)
+
+    def test_does_not_clear_spool_values_when_remembering(self):
+        """Covers the `not self.remember_spool` guard's False branch."""
+        lane = self._make_lane(remember_spool=True)
+        lane.cmd_AFC_RECOVER_LANE(MagicMock())
+        lane.afc.spool.clear_values.assert_not_called()
+
+    def test_calls_lane_not_ready(self):
+        lane = self._make_lane()
+        lane.cmd_AFC_RECOVER_LANE(MagicMock())
+        lane.unit_obj.lane_not_ready.assert_called_once_with(lane)
+
+    def test_saves_vars(self):
+        lane = self._make_lane()
+        lane.cmd_AFC_RECOVER_LANE(MagicMock())
+        lane.afc.save_vars.assert_called_once_with()
+
+    def test_logs_reset_message_with_lane_name(self):
+        lane = self._make_lane()
+        lane.cmd_AFC_RECOVER_LANE(MagicMock())
+        assert lane.logger.messages == [("info", f"{lane.name} reset")]
+
+
 class TestCmdSetLaneLoaded:
     """Tests for AFCLane.cmd_SET_LANE_LOADED."""
  
@@ -3681,6 +3809,15 @@ class TestPrepCallback:
         lane = _make_lane_ready_to_load()
         lane.prep_callback(10, True)
         lane.unit_obj.prep_load.assert_called_once_with(lane)
+
+    def test_successful_load_activates_loading_led_before_prep_load(self):
+        lane = _make_lane_ready_to_load()
+        order = []
+        lane.unit_obj.lane_loading.side_effect = lambda *a, **kw: order.append("lane_loading")
+        lane.unit_obj.prep_load.side_effect = lambda *a, **kw: order.append("prep_load")
+        lane.prep_callback(10, True)
+        lane.unit_obj.lane_loading.assert_called_once_with(lane)
+        assert order == ["lane_loading", "prep_load"]
 
     def test_successful_load_resets_status_to_none(self):
         lane = _make_lane_ready_to_load()

--- a/tests/test_AFC_lane.py
+++ b/tests/test_AFC_lane.py
@@ -2847,7 +2847,7 @@ class TestPerformInfiniteRunout:
         info_msgs = [m for lvl, m in lane.logger.messages if lvl == "info"]
 
         assert lane.status is AFCLaneState.NONE
-        lane.unit_obj.lane_not_ready.assert_called_with(lane)
+        lane.unit_obj.lane_not_ready.assert_not_called()
         assert any(f"Infinite Spool triggered for {lane.name}" in m for m in info_msgs), info_msgs
         afc.lanes.get.assert_called_with(afc.current)
         assert afc.lanes.get.call_count == 1

--- a/tests/test_AFC_spool.py
+++ b/tests/test_AFC_spool.py
@@ -744,7 +744,7 @@ class TestSetColor:
         spool.afc.lanes = {"lane1": lane}
         gcmd = _make_gcmd(LANE="lane1", COLOR="#FF0000")
         spool.cmd_SET_COLOR(gcmd)
-        lane.unit_obj.lane_loaded.assert_called_once_with(lane)
+        lane.unit_obj.lane_loaded.assert_called_once_with(lane, force=True)
         
 
     def test_not_set_led_lane_loaded_not_lane_in_unit(self):
@@ -1584,7 +1584,7 @@ class TestSetSpoolID:
         result = _make_spool_result()
         spool.afc.moonraker.get_spool = MagicMock(return_value=result)
         spool.set_spoolID(lane, 42)
-        lane.unit_obj.lane_loaded.assert_called_once_with(lane)
+        lane.unit_obj.lane_loaded.assert_called_once_with(lane, force=True)
     
     def test_valid_spool_id_lane_loaded_lane_not_in_unit(self):
         spool = self._make_spool_with_spoolman()

--- a/tests/test_AFC_spool.py
+++ b/tests/test_AFC_spool.py
@@ -744,7 +744,7 @@ class TestSetColor:
         spool.afc.lanes = {"lane1": lane}
         gcmd = _make_gcmd(LANE="lane1", COLOR="#FF0000")
         spool.cmd_SET_COLOR(gcmd)
-        spool.afc.function.afc_led.assert_called()
+        lane.unit_obj.lane_loaded.assert_called_once_with(lane)
         
 
     def test_not_set_led_lane_loaded_not_lane_in_unit(self):
@@ -1584,7 +1584,7 @@ class TestSetSpoolID:
         result = _make_spool_result()
         spool.afc.moonraker.get_spool = MagicMock(return_value=result)
         spool.set_spoolID(lane, 42)
-        spool.afc.function.afc_led.assert_called()
+        lane.unit_obj.lane_loaded.assert_called_once_with(lane)
     
     def test_valid_spool_id_lane_loaded_lane_not_in_unit(self):
         spool = self._make_spool_with_spoolman()

--- a/tests/test_AFC_unit.py
+++ b/tests/test_AFC_unit.py
@@ -468,6 +468,25 @@ class TestLedStateDedup:
         unit.lane_loaded(lane)
         assert unit._trigger_led_state.call_count == 1
 
+    def test_lane_loaded_force_true_reapplies_even_when_already_loaded(self):
+        """force=True bypasses the dedup skip, used when only the filament
+        color changed while the lane stayed in the "loaded" state."""
+        unit = _make_unit()
+        lane = _make_lane()
+        unit._trigger_led_state = MagicMock()
+        unit.lane_loaded(lane)
+        unit.lane_loaded(lane, force=True)
+        assert unit._trigger_led_state.call_count == 2
+
+    def test_lane_loaded_force_false_default_still_skips_when_already_loaded(self):
+        """Covers force's default value (False) taking the normal dedup path."""
+        unit = _make_unit()
+        lane = _make_lane()
+        unit._trigger_led_state = MagicMock()
+        unit.lane_loaded(lane)
+        unit.lane_loaded(lane, force=False)
+        assert unit._trigger_led_state.call_count == 1
+
     def test_lane_unloading_skips_when_already_unloading(self):
         unit = _make_unit()
         lane = _make_lane()

--- a/tests/test_AFC_unit.py
+++ b/tests/test_AFC_unit.py
@@ -298,6 +298,23 @@ class TestLaneStatusLeds:
         unit.lane_not_ready(lane)
         unit.afc.function.afc_led.assert_called_once_with(lane.led_not_ready, lane.led_index)
 
+    def test_lane_not_ready_turns_off_spool_led_when_spool_index_set(self):
+        """Covers the `lane.led_spool_index is not None` True branch."""
+        unit = _make_unit()
+        lane = _make_lane()
+        lane.led_spool_index = "2"
+        unit.lane_not_ready(lane)
+        unit.afc.function.afc_led.assert_any_call(unit.afc.led_off, "2")
+
+    def test_lane_not_ready_skips_spool_led_when_spool_index_none(self):
+        """Covers the `lane.led_spool_index is not None` False branch."""
+        unit = _make_unit()
+        lane = _make_lane()
+        lane.led_spool_index = None
+        unit.lane_not_ready(lane)
+        for c in unit.afc.function.afc_led.call_args_list:
+            assert c[0][0] != unit.afc.led_off
+
     def test_lane_loaded_calls_afc_led_with_ready_color(self):
         unit = _make_unit()
         lane = _make_lane()
@@ -324,13 +341,15 @@ class TestLaneStatusLeds:
         unit.lane_unloaded(lane)
         unit.afc.function.afc_led.assert_called_once_with(lane.led_not_ready, lane.led_index)
 
-    def test_lane_unloaded_turns_off_spool_led_when_spool_index_set(self):
-        """Covers the `lane.led_spool_index is not None` True branch."""
+    def test_lane_unloaded_does_not_touch_spool_led(self):
+        """lane_unloaded no longer manages the spool illumination LED --
+        that responsibility moved to lane_not_ready."""
         unit = _make_unit()
         lane = _make_lane()
         lane.led_spool_index = "2"
         unit.lane_unloaded(lane)
-        unit.afc.function.afc_led.assert_any_call(unit.afc.led_off, "2")
+        for c in unit.afc.function.afc_led.call_args_list:
+            assert c[0][0] != unit.afc.led_off
 
     def test_lane_loading_calls_afc_led_with_loading_color(self):
         unit = _make_unit()

--- a/tests/test_AFC_unit.py
+++ b/tests/test_AFC_unit.py
@@ -387,11 +387,38 @@ class TestStopLedEffects:
         ])
         assert unit.gcode.run_script_from_command.call_count == 2
 
+    def test_clears_active_led_effects_after_stopping(self):
+        unit = _make_unit()
+        unit.afc.active_led_effects = ["lane1_loaded", "lane2_fault"]
+        unit._stop_led_effects()
+        assert unit.afc.active_led_effects == []
+
     def test_exception_from_gcode_is_swallowed(self):
         unit = _make_unit()
         unit.afc.active_led_effects = ["lane1_loaded"]
         unit.gcode.run_script_from_command.side_effect = Exception("boom")
         unit._stop_led_effects()  # must not raise
+
+    def test_exception_on_one_effect_does_not_skip_remaining_effects(self):
+        """The try/except is now per-iteration, not around the whole loop:
+        a failure stopping one effect must not prevent the rest from being
+        attempted too."""
+        unit = _make_unit()
+        unit.afc.active_led_effects = ["lane1_loaded", "lane2_fault"]
+        unit.gcode.run_script_from_command.side_effect = [Exception("boom"), None]
+        unit._stop_led_effects()
+        unit.gcode.run_script_from_command.assert_has_calls([
+            call("SET_LED_EFFECT EFFECT=lane1_loaded STOP=1"),
+            call("SET_LED_EFFECT EFFECT=lane2_fault STOP=1"),
+        ])
+        assert unit.gcode.run_script_from_command.call_count == 2
+
+    def test_clears_active_led_effects_even_when_stopping_raised(self):
+        unit = _make_unit()
+        unit.afc.active_led_effects = ["lane1_loaded"]
+        unit.gcode.run_script_from_command.side_effect = Exception("boom")
+        unit._stop_led_effects()
+        assert unit.afc.active_led_effects == []
 
 
 # ── _trigger_led_state ───────────────────────────────────────────────────────

--- a/tests/test_AFC_unit.py
+++ b/tests/test_AFC_unit.py
@@ -64,8 +64,11 @@ def _make_lane(name="lane1", hub="hub1", extruder="ext1", buffer_name="buf1"):
     lane.led_ready = "0,1,0,0"
     lane.led_not_ready = "0,0,0,0.25"
     lane.led_loading = "0,0,1,0"
+    lane.led_unloading = "0,0,1,0.5"
     lane.led_tool_loaded = "0,1,0,0"
     lane.led_tool_unloaded = "0,1,0,0"
+    lane.led_tool_loaded_idle = "0,0.5,0,0"
+    lane.led_fault = "1,0,0,0"
     lane.led_index = "1"
     lane.led_spool_illum = "1,1,1,0"
     lane.led_use_filament_color = False
@@ -288,17 +291,45 @@ class TestOnFilamentRemove:
 # ── LED helpers ───────────────────────────────────────────────────────────────
 
 class TestLaneStatusLeds:
+    def test_lane_not_ready_calls_afc_led_with_not_ready_color(self):
+        unit = _make_unit()
+        lane = _make_lane()
+        unit.lane_not_ready(lane)
+        unit.afc.function.afc_led.assert_called_once_with(lane.led_not_ready, lane.led_index)
+
     def test_lane_loaded_calls_afc_led_with_ready_color(self):
         unit = _make_unit()
         lane = _make_lane()
         unit.lane_loaded(lane)
         unit.afc.function.afc_led.assert_called_once_with(lane.led_ready, lane.led_index)
 
+    def test_lane_loaded_illuminates_spool_led_when_spool_index_set(self):
+        """Covers the `lane.led_spool_index is not None` True branch."""
+        unit = _make_unit()
+        lane = _make_lane()
+        lane.led_spool_index = "2"
+        unit.lane_loaded(lane)
+        unit.afc.function.afc_led.assert_any_call(lane.led_spool_illum, "2")
+
+    def test_lane_unloading_calls_afc_led_with_unloading_color(self):
+        unit = _make_unit()
+        lane = _make_lane()
+        unit.lane_unloading(lane)
+        unit.afc.function.afc_led.assert_called_once_with(lane.led_unloading, lane.led_index)
+
     def test_lane_unloaded_calls_afc_led_with_not_ready_color(self):
         unit = _make_unit()
         lane = _make_lane()
         unit.lane_unloaded(lane)
         unit.afc.function.afc_led.assert_called_once_with(lane.led_not_ready, lane.led_index)
+
+    def test_lane_unloaded_turns_off_spool_led_when_spool_index_set(self):
+        """Covers the `lane.led_spool_index is not None` True branch."""
+        unit = _make_unit()
+        lane = _make_lane()
+        lane.led_spool_index = "2"
+        unit.lane_unloaded(lane)
+        unit.afc.function.afc_led.assert_any_call(unit.afc.led_off, "2")
 
     def test_lane_loading_calls_afc_led_with_loading_color(self):
         unit = _make_unit()
@@ -321,6 +352,218 @@ class TestLaneStatusLeds:
         unit.lane_tool_unloaded(lane)
         unit.afc.function.afc_led.assert_called_once_with(lane.led_ready, lane.led_index)
         lane.extruder_obj.set_status_led.assert_called_once_with(lane.led_tool_unloaded)
+
+    def test_lane_tool_loaded_idle_calls_afc_led_with_idle_color(self):
+        unit = _make_unit()
+        lane = _make_lane()
+        lane.extruder_obj = MagicMock()
+        unit.lane_tool_loaded_idle(lane)
+        unit.afc.function.afc_led.assert_called_once_with(lane.led_tool_loaded_idle, lane.led_index)
+        lane.extruder_obj.set_status_led.assert_called_once_with(lane.led_tool_loaded_idle)
+
+    def test_lane_fault_calls_afc_led_with_fault_color(self):
+        unit = _make_unit()
+        lane = _make_lane()
+        unit.lane_fault(lane)
+        unit.afc.function.afc_led.assert_called_once_with(lane.led_fault, lane.led_index)
+
+
+# ── _stop_led_effects ────────────────────────────────────────────────────────
+
+class TestStopLedEffects:
+    def test_no_active_effects_does_not_call_gcode(self):
+        unit = _make_unit()
+        unit.afc.active_led_effects = []
+        unit._stop_led_effects()
+        unit.gcode.run_script_from_command.assert_not_called()
+
+    def test_stops_each_active_effect(self):
+        unit = _make_unit()
+        unit.afc.active_led_effects = ["lane1_loaded", "lane2_fault"]
+        unit._stop_led_effects()
+        unit.gcode.run_script_from_command.assert_has_calls([
+            call("SET_LED_EFFECT EFFECT=lane1_loaded STOP=1"),
+            call("SET_LED_EFFECT EFFECT=lane2_fault STOP=1"),
+        ])
+        assert unit.gcode.run_script_from_command.call_count == 2
+
+    def test_exception_from_gcode_is_swallowed(self):
+        unit = _make_unit()
+        unit.afc.active_led_effects = ["lane1_loaded"]
+        unit.gcode.run_script_from_command.side_effect = Exception("boom")
+        unit._stop_led_effects()  # must not raise
+
+
+# ── _trigger_led_state ───────────────────────────────────────────────────────
+
+class TestTriggerLedState:
+    def test_stops_active_effects_first(self):
+        unit = _make_unit()
+        lane = _make_lane()
+        unit._stop_led_effects = MagicMock()
+        unit._trigger_led_state(lane, lane.led_ready)
+        unit._stop_led_effects.assert_called_once_with()
+
+    def test_applies_static_color(self):
+        unit = _make_unit()
+        lane = _make_lane()
+        unit._trigger_led_state(lane, lane.led_ready)
+        unit.afc.function.afc_led.assert_called_once_with(lane.led_ready, lane.led_index)
+
+    def test_none_static_color_skips_afc_led(self):
+        """Covers the `static_color is not None` guard's False branch."""
+        unit = _make_unit()
+        lane = _make_lane()
+        unit._trigger_led_state(lane, None)
+        unit.afc.function.afc_led.assert_not_called()
+
+    def test_no_effect_suffix_does_not_touch_printer_objects(self):
+        """Covers the `if effect_suffix:` guard's False branch (default None)."""
+        unit = _make_unit()
+        lane = _make_lane()
+        unit._trigger_led_state(lane, lane.led_ready)
+        unit.gcode.run_script_from_command.assert_not_called()
+        assert unit.afc.active_led_effects == []
+
+    def test_empty_string_effect_suffix_does_not_touch_printer_objects(self):
+        """Covers `if effect_suffix:` treating "" as falsy, distinct from None."""
+        unit = _make_unit()
+        lane = _make_lane()
+        unit._trigger_led_state(lane, lane.led_ready, "")
+        unit.gcode.run_script_from_command.assert_not_called()
+        assert unit.afc.active_led_effects == []
+
+    def test_effect_present_in_printer_objects_runs_set_led_effect(self):
+        unit = _make_unit()
+        lane = _make_lane()
+        unit.printer.objects["led_effect lane1_loaded"] = MagicMock()
+        unit._trigger_led_state(lane, lane.led_ready, "loaded")
+        unit.gcode.run_script_from_command.assert_called_once_with(
+            "SET_LED_EFFECT EFFECT=lane1_loaded")
+        assert unit.afc.active_led_effects == ["lane1_loaded"]
+
+    def test_effect_not_present_in_printer_objects_skips_set_led_effect(self):
+        unit = _make_unit()
+        lane = _make_lane()
+        # printer.objects has no "led_effect lane1_loaded" entry
+        unit._trigger_led_state(lane, lane.led_ready, "loaded")
+        unit.gcode.run_script_from_command.assert_not_called()
+        assert unit.afc.active_led_effects == []
+
+    def test_exception_running_effect_is_swallowed_and_not_recorded(self):
+        unit = _make_unit()
+        lane = _make_lane()
+        unit.printer.objects["led_effect lane1_loaded"] = MagicMock()
+        unit.gcode.run_script_from_command.side_effect = Exception("boom")
+        unit._trigger_led_state(lane, lane.led_ready, "loaded")  # must not raise
+        assert unit.afc.active_led_effects == []
+
+    def test_static_color_still_applied_when_effect_lookup_raises(self):
+        """The static color branch runs (and completes) before the effect
+        branch, so a failure overlaying the effect doesn't undo it."""
+        unit = _make_unit()
+        lane = _make_lane()
+        unit.printer.objects["led_effect lane1_loaded"] = MagicMock()
+        unit.gcode.run_script_from_command.side_effect = Exception("boom")
+        unit._trigger_led_state(lane, lane.led_ready, "loaded")
+        unit.afc.function.afc_led.assert_called_once_with(lane.led_ready, lane.led_index)
+
+
+# ── lane_* -> _trigger_led_state suffix wiring ────────────────────────────────
+
+class TestLedEffectSuffixMapping:
+    """Each lane_* status method must delegate to _trigger_led_state with its
+    own distinct effect suffix, so a `led_effect <lane>_<suffix>` macro can
+    target that specific state independently of the others."""
+
+    def test_lane_not_ready_uses_not_ready_suffix(self):
+        unit = _make_unit()
+        lane = _make_lane()
+        unit._trigger_led_state = MagicMock()
+        unit.lane_not_ready(lane)
+        unit._trigger_led_state.assert_called_once_with(lane, lane.led_not_ready, "not_ready")
+
+    def test_lane_loaded_uses_loaded_suffix(self):
+        unit = _make_unit()
+        lane = _make_lane()
+        unit._trigger_led_state = MagicMock()
+        unit.lane_loaded(lane)
+        unit._trigger_led_state.assert_called_once_with(lane, lane.led_ready, "loaded")
+
+    def test_lane_unloading_uses_unloading_suffix(self):
+        unit = _make_unit()
+        lane = _make_lane()
+        unit._trigger_led_state = MagicMock()
+        unit.lane_unloading(lane)
+        unit._trigger_led_state.assert_called_once_with(lane, lane.led_unloading, "unloading")
+
+    def test_lane_unloaded_uses_unloaded_suffix_not_not_ready(self):
+        """lane_unloaded used to just call lane_not_ready() (suffix
+        "not_ready"); it now applies its own "unloaded" suffix so the two
+        states can trigger independent LED effect macros."""
+        unit = _make_unit()
+        lane = _make_lane()
+        unit._trigger_led_state = MagicMock()
+        unit.lane_unloaded(lane)
+        unit._trigger_led_state.assert_called_once_with(lane, lane.led_not_ready, "unloaded")
+
+    def test_lane_loading_uses_loading_suffix(self):
+        unit = _make_unit()
+        lane = _make_lane()
+        unit._trigger_led_state = MagicMock()
+        unit.lane_loading(lane)
+        unit._trigger_led_state.assert_called_once_with(lane, lane.led_loading, "loading")
+
+    def test_lane_tool_loaded_uses_tool_loaded_suffix(self):
+        unit = _make_unit()
+        lane = _make_lane()
+        lane.extruder_obj = MagicMock()
+        unit._trigger_led_state = MagicMock()
+        unit.lane_tool_loaded(lane)
+        unit._trigger_led_state.assert_called_once_with(lane, lane.led_tool_loaded, "tool_loaded")
+
+    def test_lane_tool_unloaded_uses_tool_unloaded_suffix(self):
+        unit = _make_unit()
+        lane = _make_lane()
+        lane.extruder_obj = MagicMock()
+        unit._trigger_led_state = MagicMock()
+        unit.lane_tool_unloaded(lane)
+        unit._trigger_led_state.assert_called_once_with(lane, lane.led_ready, "tool_unloaded")
+
+    def test_lane_tool_loaded_idle_uses_tool_loaded_idle_suffix(self):
+        unit = _make_unit()
+        lane = _make_lane()
+        lane.extruder_obj = MagicMock()
+        unit._trigger_led_state = MagicMock()
+        unit.lane_tool_loaded_idle(lane)
+        unit._trigger_led_state.assert_called_once_with(
+            lane, lane.led_tool_loaded_idle, "tool_loaded_idle")
+
+    def test_lane_fault_uses_fault_suffix(self):
+        unit = _make_unit()
+        lane = _make_lane()
+        unit._trigger_led_state = MagicMock()
+        unit.lane_fault(lane)
+        unit._trigger_led_state.assert_called_once_with(lane, lane.led_fault, "fault")
+
+
+# ── lane_illuminate_spool ────────────────────────────────────────────────────
+
+class TestLaneIlluminateSpool:
+    def test_illuminates_spool_led_when_spool_index_set(self):
+        unit = _make_unit()
+        lane = _make_lane()
+        lane.led_spool_index = "2"
+        unit.lane_illuminate_spool(lane)
+        unit.afc.function.afc_led.assert_called_once_with(lane.led_spool_illum, "2")
+
+    def test_no_call_when_spool_index_is_none(self):
+        """Covers the `lane.led_spool_index is not None` False branch."""
+        unit = _make_unit()
+        lane = _make_lane()
+        lane.led_spool_index = None
+        unit.lane_illuminate_spool(lane)
+        unit.afc.function.afc_led.assert_not_called()
 
 
 # ── led_use_filament_color ─────────────────────────────────────────────────────

--- a/tests/test_AFC_unit.py
+++ b/tests/test_AFC_unit.py
@@ -428,27 +428,27 @@ class TestTriggerLedState:
         unit = _make_unit()
         lane = _make_lane()
         unit._stop_led_effects = MagicMock()
-        unit._trigger_led_state(lane, lane.led_ready)
+        unit._trigger_led_state(lane, static_color=lane.led_ready)
         unit._stop_led_effects.assert_called_once_with()
 
     def test_applies_static_color(self):
         unit = _make_unit()
         lane = _make_lane()
-        unit._trigger_led_state(lane, lane.led_ready)
+        unit._trigger_led_state(lane, static_color=lane.led_ready)
         unit.afc.function.afc_led.assert_called_once_with(lane.led_ready, lane.led_index)
 
     def test_none_static_color_skips_afc_led(self):
         """Covers the `static_color is not None` guard's False branch."""
         unit = _make_unit()
         lane = _make_lane()
-        unit._trigger_led_state(lane, None)
+        unit._trigger_led_state(lane, static_color=None)
         unit.afc.function.afc_led.assert_not_called()
 
     def test_no_effect_suffix_does_not_touch_printer_objects(self):
         """Covers the `if effect_suffix:` guard's False branch (default None)."""
         unit = _make_unit()
         lane = _make_lane()
-        unit._trigger_led_state(lane, lane.led_ready)
+        unit._trigger_led_state(lane, static_color=lane.led_ready)
         unit.gcode.run_script_from_command.assert_not_called()
         assert unit.afc.active_led_effects == []
 
@@ -456,7 +456,7 @@ class TestTriggerLedState:
         """Covers `if effect_suffix:` treating "" as falsy, distinct from None."""
         unit = _make_unit()
         lane = _make_lane()
-        unit._trigger_led_state(lane, lane.led_ready, "")
+        unit._trigger_led_state(lane, static_color=lane.led_ready, effect_suffix="")
         unit.gcode.run_script_from_command.assert_not_called()
         assert unit.afc.active_led_effects == []
 
@@ -464,7 +464,7 @@ class TestTriggerLedState:
         unit = _make_unit()
         lane = _make_lane()
         unit.printer.objects["led_effect lane1_loaded"] = MagicMock()
-        unit._trigger_led_state(lane, lane.led_ready, "loaded")
+        unit._trigger_led_state(lane, static_color=lane.led_ready, effect_suffix="loaded")
         unit.gcode.run_script_from_command.assert_called_once_with(
             "SET_LED_EFFECT EFFECT=lane1_loaded")
         assert unit.afc.active_led_effects == ["lane1_loaded"]
@@ -473,7 +473,7 @@ class TestTriggerLedState:
         unit = _make_unit()
         lane = _make_lane()
         # printer.objects has no "led_effect lane1_loaded" entry
-        unit._trigger_led_state(lane, lane.led_ready, "loaded")
+        unit._trigger_led_state(lane, static_color=lane.led_ready, effect_suffix="loaded")
         unit.gcode.run_script_from_command.assert_not_called()
         assert unit.afc.active_led_effects == []
 
@@ -482,7 +482,7 @@ class TestTriggerLedState:
         lane = _make_lane()
         unit.printer.objects["led_effect lane1_loaded"] = MagicMock()
         unit.gcode.run_script_from_command.side_effect = Exception("boom")
-        unit._trigger_led_state(lane, lane.led_ready, "loaded")  # must not raise
+        unit._trigger_led_state(lane, static_color=lane.led_ready, effect_suffix="loaded")  # must not raise
         assert unit.afc.active_led_effects == []
 
     def test_static_color_still_applied_when_effect_lookup_raises(self):
@@ -492,8 +492,127 @@ class TestTriggerLedState:
         lane = _make_lane()
         unit.printer.objects["led_effect lane1_loaded"] = MagicMock()
         unit.gcode.run_script_from_command.side_effect = Exception("boom")
-        unit._trigger_led_state(lane, lane.led_ready, "loaded")
+        unit._trigger_led_state(lane, static_color=lane.led_ready, effect_suffix="loaded")
         unit.afc.function.afc_led.assert_called_once_with(lane.led_ready, lane.led_index)
+
+    # ── lane is None / extruder is None combinations ──────────────────────────
+
+    def test_lane_none_and_extruder_none_returns_early(self):
+        """Covers the new `lane is None and extruder is None` guard."""
+        unit = _make_unit()
+        unit._trigger_led_state(static_color="0,1,0,0", effect_suffix="loaded")
+        unit.afc.function.afc_led.assert_not_called()
+        unit.gcode.run_script_from_command.assert_not_called()
+
+    def test_lane_none_and_extruder_none_still_stops_active_effects(self):
+        """The early return happens after _stop_led_effects(), not before."""
+        unit = _make_unit()
+        unit._stop_led_effects = MagicMock()
+        unit._trigger_led_state()
+        unit._stop_led_effects.assert_called_once_with()
+
+    def test_extruder_only_sets_extruder_led_not_lane_led(self):
+        unit = _make_unit()
+        extruder = MagicMock()
+        unit._trigger_led_state(extruder=extruder, static_color="0,1,0,0")
+        unit.afc.function.afc_led.assert_not_called()
+        extruder.set_status_led.assert_called_once_with("0,1,0,0")
+
+    def test_lane_and_extruder_both_get_static_color_when_no_override(self):
+        unit = _make_unit()
+        lane = _make_lane()
+        extruder = MagicMock()
+        unit._trigger_led_state(lane, extruder=extruder, static_color=lane.led_ready)
+        unit.afc.function.afc_led.assert_called_once_with(lane.led_ready, lane.led_index)
+        extruder.set_status_led.assert_called_once_with(lane.led_ready)
+
+    def test_extruder_static_color_overrides_static_color_for_extruder_only(self):
+        unit = _make_unit()
+        lane = _make_lane()
+        extruder = MagicMock()
+        unit._trigger_led_state(lane, extruder=extruder, static_color=lane.led_ready,
+                                extruder_static_color=lane.led_tool_unloaded)
+        unit.afc.function.afc_led.assert_called_once_with(lane.led_ready, lane.led_index)
+        extruder.set_status_led.assert_called_once_with(lane.led_tool_unloaded)
+
+    def test_extruder_static_color_ignored_when_extruder_not_given(self):
+        """extruder_static_color must not affect the lane's own LED."""
+        unit = _make_unit()
+        lane = _make_lane()
+        unit._trigger_led_state(lane, static_color=lane.led_ready,
+                                extruder_static_color=lane.led_tool_unloaded)
+        unit.afc.function.afc_led.assert_called_once_with(lane.led_ready, lane.led_index)
+
+    # ── extruder LED effect lookup ─────────────────────────────────────────────
+
+    def test_extruder_effect_present_runs_set_led_effect(self):
+        unit = _make_unit()
+        extruder = MagicMock(name="extruder")
+        extruder.name = "extruder1"
+        unit.printer.objects["led_effect extruder1_tool_loaded"] = MagicMock()
+        unit._trigger_led_state(extruder=extruder, static_color="0,1,0,0",
+                                effect_suffix="tool_loaded")
+        unit.gcode.run_script_from_command.assert_called_once_with(
+            "SET_LED_EFFECT EFFECT=extruder1_tool_loaded")
+        assert unit.afc.active_led_effects == ["extruder1_tool_loaded"]
+
+    def test_extruder_effect_not_present_skips_set_led_effect(self):
+        unit = _make_unit()
+        extruder = MagicMock(name="extruder")
+        extruder.name = "extruder1"
+        unit._trigger_led_state(extruder=extruder, static_color="0,1,0,0",
+                                effect_suffix="tool_loaded")
+        unit.gcode.run_script_from_command.assert_not_called()
+        assert unit.afc.active_led_effects == []
+
+    def test_extruder_effect_exception_is_swallowed_and_not_recorded(self):
+        unit = _make_unit()
+        extruder = MagicMock(name="extruder")
+        extruder.name = "extruder1"
+        unit.printer.objects["led_effect extruder1_tool_loaded"] = MagicMock()
+        unit.gcode.run_script_from_command.side_effect = Exception("boom")
+        unit._trigger_led_state(extruder=extruder, static_color="0,1,0,0",
+                                effect_suffix="tool_loaded")  # must not raise
+        assert unit.afc.active_led_effects == []
+
+    def test_lane_none_with_effect_suffix_only_checks_extruder_effect(self):
+        """lane_effect_name stays "" when lane is None, so the lane branch of
+        the effect lookup must never fire -- only the extruder's."""
+        unit = _make_unit()
+        extruder = MagicMock(name="extruder")
+        extruder.name = "extruder1"
+        unit.printer.objects["led_effect extruder1_tool_loaded"] = MagicMock()
+        unit._trigger_led_state(extruder=extruder, static_color="0,1,0,0",
+                                effect_suffix="tool_loaded")
+        assert unit.afc.active_led_effects == ["extruder1_tool_loaded"]
+
+    def test_lane_and_extruder_effects_both_applied_independently(self):
+        unit = _make_unit()
+        lane = _make_lane()
+        extruder = MagicMock(name="extruder")
+        extruder.name = "extruder1"
+        unit.printer.objects["led_effect lane1_tool_loaded"] = MagicMock()
+        unit.printer.objects["led_effect extruder1_tool_loaded"] = MagicMock()
+        unit._trigger_led_state(lane, extruder=extruder, static_color=lane.led_tool_loaded,
+                                effect_suffix="tool_loaded")
+        assert unit.gcode.run_script_from_command.call_args_list == [
+            call("SET_LED_EFFECT EFFECT=lane1_tool_loaded"),
+            call("SET_LED_EFFECT EFFECT=extruder1_tool_loaded"),
+        ]
+        assert unit.afc.active_led_effects == ["lane1_tool_loaded", "extruder1_tool_loaded"]
+
+    def test_lane_effect_exception_does_not_prevent_extruder_effect(self):
+        """The lane and extruder effect lookups are independently try/excepted."""
+        unit = _make_unit()
+        lane = _make_lane()
+        extruder = MagicMock(name="extruder")
+        extruder.name = "extruder1"
+        unit.printer.objects["led_effect lane1_tool_loaded"] = MagicMock()
+        unit.printer.objects["led_effect extruder1_tool_loaded"] = MagicMock()
+        unit.gcode.run_script_from_command.side_effect = [Exception("boom"), None]
+        unit._trigger_led_state(lane, extruder=extruder, static_color=lane.led_tool_loaded,
+                                effect_suffix="tool_loaded")
+        assert unit.afc.active_led_effects == ["extruder1_tool_loaded"]
 
 
 # ── lane_* -> _trigger_led_state suffix wiring ────────────────────────────────
@@ -508,21 +627,24 @@ class TestLedEffectSuffixMapping:
         lane = _make_lane()
         unit._trigger_led_state = MagicMock()
         unit.lane_not_ready(lane)
-        unit._trigger_led_state.assert_called_once_with(lane, lane.led_not_ready, "not_ready")
+        unit._trigger_led_state.assert_called_once_with(
+            lane, static_color=lane.led_not_ready, effect_suffix="not_ready")
 
     def test_lane_loaded_uses_loaded_suffix(self):
         unit = _make_unit()
         lane = _make_lane()
         unit._trigger_led_state = MagicMock()
         unit.lane_loaded(lane)
-        unit._trigger_led_state.assert_called_once_with(lane, lane.led_ready, "loaded")
+        unit._trigger_led_state.assert_called_once_with(
+            lane, static_color=lane.led_ready, effect_suffix="loaded")
 
     def test_lane_unloading_uses_unloading_suffix(self):
         unit = _make_unit()
         lane = _make_lane()
         unit._trigger_led_state = MagicMock()
         unit.lane_unloading(lane)
-        unit._trigger_led_state.assert_called_once_with(lane, lane.led_unloading, "unloading")
+        unit._trigger_led_state.assert_called_once_with(
+            lane, static_color=lane.led_unloading, effect_suffix="unloading")
 
     def test_lane_unloaded_uses_unloaded_suffix_not_not_ready(self):
         """lane_unloaded used to just call lane_not_ready() (suffix
@@ -532,14 +654,16 @@ class TestLedEffectSuffixMapping:
         lane = _make_lane()
         unit._trigger_led_state = MagicMock()
         unit.lane_unloaded(lane)
-        unit._trigger_led_state.assert_called_once_with(lane, lane.led_not_ready, "unloaded")
+        unit._trigger_led_state.assert_called_once_with(
+            lane, static_color=lane.led_not_ready, effect_suffix="unloaded")
 
     def test_lane_loading_uses_loading_suffix(self):
         unit = _make_unit()
         lane = _make_lane()
         unit._trigger_led_state = MagicMock()
         unit.lane_loading(lane)
-        unit._trigger_led_state.assert_called_once_with(lane, lane.led_loading, "loading")
+        unit._trigger_led_state.assert_called_once_with(
+            lane, static_color=lane.led_loading, effect_suffix="loading")
 
     def test_lane_tool_loaded_uses_tool_loaded_suffix(self):
         unit = _make_unit()
@@ -547,7 +671,9 @@ class TestLedEffectSuffixMapping:
         lane.extruder_obj = MagicMock()
         unit._trigger_led_state = MagicMock()
         unit.lane_tool_loaded(lane)
-        unit._trigger_led_state.assert_called_once_with(lane, lane.led_tool_loaded, "tool_loaded")
+        unit._trigger_led_state.assert_called_once_with(
+            lane, lane.extruder_obj, static_color=lane.led_tool_loaded,
+            effect_suffix="tool_loaded")
 
     def test_lane_tool_unloaded_uses_tool_unloaded_suffix(self):
         unit = _make_unit()
@@ -555,7 +681,9 @@ class TestLedEffectSuffixMapping:
         lane.extruder_obj = MagicMock()
         unit._trigger_led_state = MagicMock()
         unit.lane_tool_unloaded(lane)
-        unit._trigger_led_state.assert_called_once_with(lane, lane.led_ready, "tool_unloaded")
+        unit._trigger_led_state.assert_called_once_with(
+            lane, lane.extruder_obj, static_color=lane.led_ready,
+            extruder_static_color=lane.led_tool_unloaded, effect_suffix="tool_unloaded")
 
     def test_lane_tool_loaded_idle_uses_tool_loaded_idle_suffix(self):
         unit = _make_unit()
@@ -564,14 +692,16 @@ class TestLedEffectSuffixMapping:
         unit._trigger_led_state = MagicMock()
         unit.lane_tool_loaded_idle(lane)
         unit._trigger_led_state.assert_called_once_with(
-            lane, lane.led_tool_loaded_idle, "tool_loaded_idle")
+            lane, static_color=lane.led_tool_loaded_idle, extruder=lane.extruder_obj,
+            effect_suffix="tool_loaded_idle")
 
     def test_lane_fault_uses_fault_suffix(self):
         unit = _make_unit()
         lane = _make_lane()
         unit._trigger_led_state = MagicMock()
         unit.lane_fault(lane)
-        unit._trigger_led_state.assert_called_once_with(lane, lane.led_fault, "fault")
+        unit._trigger_led_state.assert_called_once_with(
+            lane, static_color=lane.led_fault, effect_suffix="fault")
 
 
 # ── lane_illuminate_spool ────────────────────────────────────────────────────

--- a/tests/test_AFC_unit.py
+++ b/tests/test_AFC_unit.py
@@ -1053,6 +1053,12 @@ class TestSetLogoColor:
         unit.set_logo_color(None)
         unit.afc.function.afc_led.assert_not_called()
 
+    def test_no_call_when_color_omitted(self):
+        """Covers color's new default value (None) when called with no argument."""
+        unit = _make_unit()
+        unit.set_logo_color()
+        unit.afc.function.afc_led.assert_not_called()
+
     def test_no_call_when_color_is_empty_string(self):
         unit = _make_unit()
         unit.set_logo_color("")

--- a/tests/test_AFC_unit.py
+++ b/tests/test_AFC_unit.py
@@ -76,6 +76,7 @@ def _make_lane(name="lane1", hub="hub1", extruder="ext1", buffer_name="buf1"):
     lane.short_moves_speed = 50
     lane.short_moves_accel = 50
     lane.led_spool_index = None
+    lane.current_led_state = ""
     return lane
 
 
@@ -337,6 +338,16 @@ class TestLaneStatusLeds:
         unit.lane_loading(lane)
         unit.afc.function.afc_led.assert_called_once_with(lane.led_loading, lane.led_index)
 
+    def test_lane_tool_loaded_gears_does_not_set_a_static_color(self):
+        """Unlike its siblings, lane_tool_loaded_gears passes no static_color
+        to _trigger_led_state -- it only overlays the effect."""
+        unit = _make_unit()
+        lane = _make_lane()
+        lane.extruder_obj = MagicMock()
+        unit.lane_tool_loaded_gears(lane)
+        unit.afc.function.afc_led.assert_not_called()
+        lane.extruder_obj.set_status_led.assert_not_called()
+
     def test_lane_tool_loaded_calls_afc_led_with_tool_loaded_color(self):
         unit = _make_unit()
         lane = _make_lane()
@@ -366,6 +377,156 @@ class TestLaneStatusLeds:
         lane = _make_lane()
         unit.lane_fault(lane)
         unit.afc.function.afc_led.assert_called_once_with(lane.led_fault, lane.led_index)
+
+
+# ── _check_led_state ─────────────────────────────────────────────────────────
+
+class TestCheckLedState:
+    def test_new_state_returns_true(self):
+        unit = _make_unit()
+        lane = _make_lane()
+        lane.current_led_state = "loaded"
+        assert unit._check_led_state(lane, "not_ready") is True
+
+    def test_new_state_updates_current_led_state(self):
+        unit = _make_unit()
+        lane = _make_lane()
+        lane.current_led_state = "loaded"
+        unit._check_led_state(lane, "not_ready")
+        assert lane.current_led_state == "not_ready"
+
+    def test_matching_state_returns_false(self):
+        unit = _make_unit()
+        lane = _make_lane()
+        lane.current_led_state = "loaded"
+        assert unit._check_led_state(lane, "loaded") is False
+
+    def test_matching_state_leaves_current_led_state_unchanged(self):
+        unit = _make_unit()
+        lane = _make_lane()
+        lane.current_led_state = "loaded"
+        unit._check_led_state(lane, "loaded")
+        assert lane.current_led_state == "loaded"
+
+    def test_empty_initial_state_is_not_a_match(self):
+        """The AFCLane default ("") must not collide with a real state name,
+        so the very first lane_* call for a lane isn't accidentally deduped."""
+        unit = _make_unit()
+        lane = _make_lane()
+        lane.current_led_state = ""
+        assert unit._check_led_state(lane, "not_ready") is True
+
+
+# ── lane_* LED-state dedup guards ──────────────────────────────────────────────
+
+class TestLedStateDedup:
+    """Each lane_* method must skip re-triggering the LED when called again
+    with the lane already in that state, and must proceed when the state
+    actually changes -- verified via _trigger_led_state's call count, which
+    would differ between the two branches, rather than just "no error"."""
+
+    def test_lane_not_ready_skips_when_already_not_ready(self):
+        unit = _make_unit()
+        lane = _make_lane()
+        unit._trigger_led_state = MagicMock()
+        unit.lane_not_ready(lane)
+        unit.lane_not_ready(lane)
+        assert unit._trigger_led_state.call_count == 1
+
+    def test_lane_not_ready_runs_again_after_state_changes(self):
+        unit = _make_unit()
+        lane = _make_lane()
+        unit._trigger_led_state = MagicMock()
+        unit.lane_loaded(lane)
+        unit.lane_not_ready(lane)
+        assert unit._trigger_led_state.call_count == 2
+
+    def test_lane_loaded_skips_when_already_loaded(self):
+        unit = _make_unit()
+        lane = _make_lane()
+        unit._trigger_led_state = MagicMock()
+        unit.lane_loaded(lane)
+        unit.lane_loaded(lane)
+        assert unit._trigger_led_state.call_count == 1
+
+    def test_lane_unloading_skips_when_already_unloading(self):
+        unit = _make_unit()
+        lane = _make_lane()
+        unit._trigger_led_state = MagicMock()
+        unit.lane_unloading(lane)
+        unit.lane_unloading(lane)
+        assert unit._trigger_led_state.call_count == 1
+
+    def test_lane_unloaded_skips_when_already_unloaded(self):
+        unit = _make_unit()
+        lane = _make_lane()
+        unit._trigger_led_state = MagicMock()
+        unit.lane_unloaded(lane)
+        unit.lane_unloaded(lane)
+        assert unit._trigger_led_state.call_count == 1
+
+    def test_lane_loading_skips_when_already_loading(self):
+        unit = _make_unit()
+        lane = _make_lane()
+        unit._trigger_led_state = MagicMock()
+        unit.lane_loading(lane)
+        unit.lane_loading(lane)
+        assert unit._trigger_led_state.call_count == 1
+
+    def test_lane_tool_loaded_gears_skips_when_already_tool_loaded_gears(self):
+        unit = _make_unit()
+        lane = _make_lane()
+        lane.extruder_obj = MagicMock()
+        unit._trigger_led_state = MagicMock()
+        unit.lane_tool_loaded_gears(lane)
+        unit.lane_tool_loaded_gears(lane)
+        assert unit._trigger_led_state.call_count == 1
+
+    def test_lane_tool_loaded_skips_when_already_tool_loaded(self):
+        unit = _make_unit()
+        lane = _make_lane()
+        lane.extruder_obj = MagicMock()
+        unit._trigger_led_state = MagicMock()
+        unit.lane_tool_loaded(lane)
+        unit.lane_tool_loaded(lane)
+        assert unit._trigger_led_state.call_count == 1
+
+    def test_lane_tool_unloaded_skips_when_already_tool_unloaded(self):
+        unit = _make_unit()
+        lane = _make_lane()
+        lane.extruder_obj = MagicMock()
+        unit._trigger_led_state = MagicMock()
+        unit.lane_tool_unloaded(lane)
+        unit.lane_tool_unloaded(lane)
+        assert unit._trigger_led_state.call_count == 1
+
+    def test_lane_tool_loaded_idle_skips_when_already_tool_loaded_idle(self):
+        unit = _make_unit()
+        lane = _make_lane()
+        lane.extruder_obj = MagicMock()
+        unit._trigger_led_state = MagicMock()
+        unit.lane_tool_loaded_idle(lane)
+        unit.lane_tool_loaded_idle(lane)
+        assert unit._trigger_led_state.call_count == 1
+
+    def test_lane_fault_skips_when_already_fault(self):
+        unit = _make_unit()
+        lane = _make_lane()
+        unit._trigger_led_state = MagicMock()
+        unit.lane_fault(lane)
+        unit.lane_fault(lane)
+        assert unit._trigger_led_state.call_count == 1
+
+    def test_different_lanes_are_deduped_independently(self):
+        """current_led_state lives on the lane, not the unit, so one lane's
+        state must not suppress another lane's first LED update."""
+        unit = _make_unit()
+        lane1 = _make_lane("lane1")
+        lane2 = _make_lane("lane2")
+        unit._trigger_led_state = MagicMock()
+        unit.lane_loaded(lane1)
+        unit.lane_loaded(lane2)
+        assert unit._trigger_led_state.call_count == 2
 
 
 # ── _stop_led_effects ────────────────────────────────────────────────────────
@@ -719,6 +880,15 @@ class TestLedEffectSuffixMapping:
         unit.lane_loading(lane)
         unit._trigger_led_state.assert_called_once_with(
             lane, static_color=lane.led_loading, effect_suffix="loading")
+
+    def test_lane_tool_loaded_gears_uses_tool_loaded_gears_suffix(self):
+        unit = _make_unit()
+        lane = _make_lane()
+        lane.extruder_obj = MagicMock()
+        unit._trigger_led_state = MagicMock()
+        unit.lane_tool_loaded_gears(lane)
+        unit._trigger_led_state.assert_called_once_with(
+            lane, lane.extruder_obj, effect_suffix="tool_loaded_gears")
 
     def test_lane_tool_loaded_uses_tool_loaded_suffix(self):
         unit = _make_unit()

--- a/tests/test_AFC_unit.py
+++ b/tests/test_AFC_unit.py
@@ -65,8 +65,8 @@ def _make_lane(name="lane1", hub="hub1", extruder="ext1", buffer_name="buf1"):
     lane.led_not_ready = "0,0,0,0.25"
     lane.led_loading = "0,0,1,0"
     lane.led_unloading = "0,0,1,0.5"
-    lane.led_tool_loaded = "0,1,0,0"
-    lane.led_tool_unloaded = "0,1,0,0"
+    lane.led_tool_loaded = "0,0,1,1"
+    lane.led_tool_unloaded = "1,0,1,0"
     lane.led_tool_loaded_idle = "0,0.5,0,0"
     lane.led_fault = "1,0,0,0"
     lane.led_index = "1"
@@ -420,16 +420,79 @@ class TestStopLedEffects:
         unit._stop_led_effects()
         assert unit.afc.active_led_effects == []
 
+    # ── targets ────────────────────────────────────────────────────────────────
+
+    def test_targets_only_stops_matching_effects(self):
+        unit = _make_unit()
+        unit.afc.active_led_effects = ["lane1_loaded", "lane2_fault"]
+        unit._stop_led_effects(["lane1"])
+        unit.gcode.run_script_from_command.assert_called_once_with(
+            "SET_LED_EFFECT EFFECT=lane1_loaded STOP=1")
+
+    def test_targets_leaves_non_matching_effects_in_active_list(self):
+        unit = _make_unit()
+        unit.afc.active_led_effects = ["lane1_loaded", "lane2_fault"]
+        unit._stop_led_effects(["lane1"])
+        assert unit.afc.active_led_effects == ["lane2_fault"]
+
+    def test_targets_matches_multiple_names(self):
+        unit = _make_unit()
+        unit.afc.active_led_effects = ["lane1_loaded", "lane2_fault", "extruder1_tool_loaded"]
+        unit._stop_led_effects(["lane1", "extruder1"])
+        assert unit.afc.active_led_effects == ["lane2_fault"]
+
+    def test_targets_no_match_stops_nothing(self):
+        unit = _make_unit()
+        unit.afc.active_led_effects = ["lane2_fault"]
+        unit._stop_led_effects(["lane1"])
+        unit.gcode.run_script_from_command.assert_not_called()
+        assert unit.afc.active_led_effects == ["lane2_fault"]
+
+    def test_targets_empty_list_stops_nothing(self):
+        """An empty target list is distinct from targets=None -- neither
+        matches any effect, so everything is preserved rather than cleared."""
+        unit = _make_unit()
+        unit.afc.active_led_effects = ["lane1_loaded"]
+        unit._stop_led_effects([])
+        unit.gcode.run_script_from_command.assert_not_called()
+        assert unit.afc.active_led_effects == ["lane1_loaded"]
+
+    def test_targets_does_not_prefix_match_across_similar_names(self):
+        """Target "lane1" must not match "lane10_loaded" -- the match requires
+        the full "<target>_" prefix, not just a substring."""
+        unit = _make_unit()
+        unit.afc.active_led_effects = ["lane10_loaded"]
+        unit._stop_led_effects(["lane1"])
+        unit.gcode.run_script_from_command.assert_not_called()
+        assert unit.afc.active_led_effects == ["lane10_loaded"]
+
 
 # ── _trigger_led_state ───────────────────────────────────────────────────────
 
 class TestTriggerLedState:
-    def test_stops_active_effects_first(self):
+    def test_stops_only_lane_effects_when_only_lane_given(self):
         unit = _make_unit()
         lane = _make_lane()
         unit._stop_led_effects = MagicMock()
         unit._trigger_led_state(lane, static_color=lane.led_ready)
-        unit._stop_led_effects.assert_called_once_with()
+        unit._stop_led_effects.assert_called_once_with([lane.name])
+
+    def test_stops_only_extruder_effects_when_only_extruder_given(self):
+        unit = _make_unit()
+        extruder = MagicMock()
+        extruder.name = "extruder1"
+        unit._stop_led_effects = MagicMock()
+        unit._trigger_led_state(extruder=extruder, static_color="0,1,0,0")
+        unit._stop_led_effects.assert_called_once_with(["extruder1"])
+
+    def test_stops_both_lane_and_extruder_effects_when_both_given(self):
+        unit = _make_unit()
+        lane = _make_lane()
+        extruder = MagicMock()
+        extruder.name = "extruder1"
+        unit._stop_led_effects = MagicMock()
+        unit._trigger_led_state(lane, extruder=extruder, static_color=lane.led_ready)
+        unit._stop_led_effects.assert_called_once_with([lane.name, "extruder1"])
 
     def test_applies_static_color(self):
         unit = _make_unit()
@@ -444,56 +507,28 @@ class TestTriggerLedState:
         unit._trigger_led_state(lane, static_color=None)
         unit.afc.function.afc_led.assert_not_called()
 
-    def test_no_effect_suffix_does_not_touch_printer_objects(self):
+    def test_no_effect_suffix_does_not_call_call_led_effect(self):
         """Covers the `if effect_suffix:` guard's False branch (default None)."""
         unit = _make_unit()
         lane = _make_lane()
+        unit._call_led_effect = MagicMock()
         unit._trigger_led_state(lane, static_color=lane.led_ready)
-        unit.gcode.run_script_from_command.assert_not_called()
-        assert unit.afc.active_led_effects == []
+        unit._call_led_effect.assert_not_called()
 
-    def test_empty_string_effect_suffix_does_not_touch_printer_objects(self):
+    def test_empty_string_effect_suffix_does_not_call_call_led_effect(self):
         """Covers `if effect_suffix:` treating "" as falsy, distinct from None."""
         unit = _make_unit()
         lane = _make_lane()
+        unit._call_led_effect = MagicMock()
         unit._trigger_led_state(lane, static_color=lane.led_ready, effect_suffix="")
-        unit.gcode.run_script_from_command.assert_not_called()
-        assert unit.afc.active_led_effects == []
+        unit._call_led_effect.assert_not_called()
 
-    def test_effect_present_in_printer_objects_runs_set_led_effect(self):
+    def test_effect_suffix_calls_call_led_effect_with_lane_name(self):
         unit = _make_unit()
         lane = _make_lane()
-        unit.printer.objects["led_effect lane1_loaded"] = MagicMock()
+        unit._call_led_effect = MagicMock()
         unit._trigger_led_state(lane, static_color=lane.led_ready, effect_suffix="loaded")
-        unit.gcode.run_script_from_command.assert_called_once_with(
-            "SET_LED_EFFECT EFFECT=lane1_loaded")
-        assert unit.afc.active_led_effects == ["lane1_loaded"]
-
-    def test_effect_not_present_in_printer_objects_skips_set_led_effect(self):
-        unit = _make_unit()
-        lane = _make_lane()
-        # printer.objects has no "led_effect lane1_loaded" entry
-        unit._trigger_led_state(lane, static_color=lane.led_ready, effect_suffix="loaded")
-        unit.gcode.run_script_from_command.assert_not_called()
-        assert unit.afc.active_led_effects == []
-
-    def test_exception_running_effect_is_swallowed_and_not_recorded(self):
-        unit = _make_unit()
-        lane = _make_lane()
-        unit.printer.objects["led_effect lane1_loaded"] = MagicMock()
-        unit.gcode.run_script_from_command.side_effect = Exception("boom")
-        unit._trigger_led_state(lane, static_color=lane.led_ready, effect_suffix="loaded")  # must not raise
-        assert unit.afc.active_led_effects == []
-
-    def test_static_color_still_applied_when_effect_lookup_raises(self):
-        """The static color branch runs (and completes) before the effect
-        branch, so a failure overlaying the effect doesn't undo it."""
-        unit = _make_unit()
-        lane = _make_lane()
-        unit.printer.objects["led_effect lane1_loaded"] = MagicMock()
-        unit.gcode.run_script_from_command.side_effect = Exception("boom")
-        unit._trigger_led_state(lane, static_color=lane.led_ready, effect_suffix="loaded")
-        unit.afc.function.afc_led.assert_called_once_with(lane.led_ready, lane.led_index)
+        unit._call_led_effect.assert_called_once_with(lane.name, "loaded")
 
     # ── lane is None / extruder is None combinations ──────────────────────────
 
@@ -504,12 +539,14 @@ class TestTriggerLedState:
         unit.afc.function.afc_led.assert_not_called()
         unit.gcode.run_script_from_command.assert_not_called()
 
-    def test_lane_none_and_extruder_none_still_stops_active_effects(self):
-        """The early return happens after _stop_led_effects(), not before."""
+    def test_lane_none_and_extruder_none_does_not_stop_effects(self):
+        """The early return now happens before _stop_led_effects() runs, so
+        neither lane nor extruder being given must skip it entirely --
+        there's nothing to scope the stop to."""
         unit = _make_unit()
         unit._stop_led_effects = MagicMock()
         unit._trigger_led_state()
-        unit._stop_led_effects.assert_called_once_with()
+        unit._stop_led_effects.assert_not_called()
 
     def test_extruder_only_sets_extruder_led_not_lane_led(self):
         unit = _make_unit()
@@ -543,76 +580,94 @@ class TestTriggerLedState:
                                 extruder_static_color=lane.led_tool_unloaded)
         unit.afc.function.afc_led.assert_called_once_with(lane.led_ready, lane.led_index)
 
-    # ── extruder LED effect lookup ─────────────────────────────────────────────
+    # ── extruder LED effect delegation ─────────────────────────────────────────
 
-    def test_extruder_effect_present_runs_set_led_effect(self):
+    def test_effect_suffix_calls_call_led_effect_with_extruder_name(self):
         unit = _make_unit()
         extruder = MagicMock(name="extruder")
         extruder.name = "extruder1"
-        unit.printer.objects["led_effect extruder1_tool_loaded"] = MagicMock()
+        unit._call_led_effect = MagicMock()
         unit._trigger_led_state(extruder=extruder, static_color="0,1,0,0",
                                 effect_suffix="tool_loaded")
-        unit.gcode.run_script_from_command.assert_called_once_with(
-            "SET_LED_EFFECT EFFECT=extruder1_tool_loaded")
-        assert unit.afc.active_led_effects == ["extruder1_tool_loaded"]
+        unit._call_led_effect.assert_called_once_with("extruder1", "tool_loaded")
 
-    def test_extruder_effect_not_present_skips_set_led_effect(self):
+    def test_lane_none_only_calls_call_led_effect_for_extruder(self):
         unit = _make_unit()
         extruder = MagicMock(name="extruder")
         extruder.name = "extruder1"
+        unit._call_led_effect = MagicMock()
         unit._trigger_led_state(extruder=extruder, static_color="0,1,0,0",
                                 effect_suffix="tool_loaded")
-        unit.gcode.run_script_from_command.assert_not_called()
-        assert unit.afc.active_led_effects == []
+        unit._call_led_effect.assert_called_once_with("extruder1", "tool_loaded")
 
-    def test_extruder_effect_exception_is_swallowed_and_not_recorded(self):
+    def test_extruder_none_only_calls_call_led_effect_for_lane(self):
         unit = _make_unit()
-        extruder = MagicMock(name="extruder")
-        extruder.name = "extruder1"
-        unit.printer.objects["led_effect extruder1_tool_loaded"] = MagicMock()
-        unit.gcode.run_script_from_command.side_effect = Exception("boom")
-        unit._trigger_led_state(extruder=extruder, static_color="0,1,0,0",
-                                effect_suffix="tool_loaded")  # must not raise
-        assert unit.afc.active_led_effects == []
+        lane = _make_lane()
+        unit._call_led_effect = MagicMock()
+        unit._trigger_led_state(lane, static_color=lane.led_ready, effect_suffix="loaded")
+        unit._call_led_effect.assert_called_once_with(lane.name, "loaded")
 
-    def test_lane_none_with_effect_suffix_only_checks_extruder_effect(self):
-        """lane_effect_name stays "" when lane is None, so the lane branch of
-        the effect lookup must never fire -- only the extruder's."""
-        unit = _make_unit()
-        extruder = MagicMock(name="extruder")
-        extruder.name = "extruder1"
-        unit.printer.objects["led_effect extruder1_tool_loaded"] = MagicMock()
-        unit._trigger_led_state(extruder=extruder, static_color="0,1,0,0",
-                                effect_suffix="tool_loaded")
-        assert unit.afc.active_led_effects == ["extruder1_tool_loaded"]
-
-    def test_lane_and_extruder_effects_both_applied_independently(self):
+    def test_lane_and_extruder_both_call_call_led_effect_independently(self):
         unit = _make_unit()
         lane = _make_lane()
         extruder = MagicMock(name="extruder")
         extruder.name = "extruder1"
-        unit.printer.objects["led_effect lane1_tool_loaded"] = MagicMock()
-        unit.printer.objects["led_effect extruder1_tool_loaded"] = MagicMock()
+        unit._call_led_effect = MagicMock()
         unit._trigger_led_state(lane, extruder=extruder, static_color=lane.led_tool_loaded,
                                 effect_suffix="tool_loaded")
-        assert unit.gcode.run_script_from_command.call_args_list == [
-            call("SET_LED_EFFECT EFFECT=lane1_tool_loaded"),
-            call("SET_LED_EFFECT EFFECT=extruder1_tool_loaded"),
+        assert unit._call_led_effect.call_args_list == [
+            call(lane.name, "tool_loaded"),
+            call("extruder1", "tool_loaded"),
         ]
-        assert unit.afc.active_led_effects == ["lane1_tool_loaded", "extruder1_tool_loaded"]
 
-    def test_lane_effect_exception_does_not_prevent_extruder_effect(self):
-        """The lane and extruder effect lookups are independently try/excepted."""
+
+# ── _call_led_effect ─────────────────────────────────────────────────────────
+
+class TestCallLedEffect:
+    def test_effect_present_calls_set_led_effect_with_constructed_name(self):
         unit = _make_unit()
-        lane = _make_lane()
-        extruder = MagicMock(name="extruder")
-        extruder.name = "extruder1"
-        unit.printer.objects["led_effect lane1_tool_loaded"] = MagicMock()
-        unit.printer.objects["led_effect extruder1_tool_loaded"] = MagicMock()
-        unit.gcode.run_script_from_command.side_effect = [Exception("boom"), None]
-        unit._trigger_led_state(lane, extruder=extruder, static_color=lane.led_tool_loaded,
-                                effect_suffix="tool_loaded")
-        assert unit.afc.active_led_effects == ["extruder1_tool_loaded"]
+        unit.printer.objects["led_effect lane1_loaded"] = MagicMock()
+        unit._call_led_effect("lane1", "loaded")
+        unit.gcode.run_script_from_command.assert_called_once_with(
+            "SET_LED_EFFECT EFFECT=lane1_loaded")
+
+    def test_effect_present_appends_constructed_name_to_active_led_effects(self):
+        unit = _make_unit()
+        unit.printer.objects["led_effect lane1_loaded"] = MagicMock()
+        unit._call_led_effect("lane1", "loaded")
+        assert unit.afc.active_led_effects == ["lane1_loaded"]
+
+    def test_effect_present_appends_to_existing_active_led_effects_without_clearing(self):
+        unit = _make_unit()
+        unit.printer.objects["led_effect lane1_loaded"] = MagicMock()
+        unit.afc.active_led_effects = ["lane2_fault"]
+        unit._call_led_effect("lane1", "loaded")
+        assert unit.afc.active_led_effects == ["lane2_fault", "lane1_loaded"]
+
+    def test_effect_not_present_skips_set_led_effect(self):
+        unit = _make_unit()
+        # printer.objects has no "led_effect lane1_loaded" entry
+        unit._call_led_effect("lane1", "loaded")
+        unit.gcode.run_script_from_command.assert_not_called()
+
+    def test_effect_not_present_does_not_append_to_active_led_effects(self):
+        unit = _make_unit()
+        # printer.objects has no "led_effect lane1_loaded" entry
+        unit._call_led_effect("lane1", "loaded")
+        assert unit.afc.active_led_effects == []
+
+    def test_exception_does_not_raise(self):
+        unit = _make_unit()
+        unit.printer.objects["led_effect lane1_loaded"] = MagicMock()
+        unit.gcode.run_script_from_command.side_effect = Exception("boom")
+        unit._call_led_effect("lane1", "loaded")  # must not raise
+
+    def test_exception_prevents_append_to_active_led_effects(self):
+        unit = _make_unit()
+        unit.printer.objects["led_effect lane1_loaded"] = MagicMock()
+        unit.gcode.run_script_from_command.side_effect = Exception("boom")
+        unit._call_led_effect("lane1", "loaded")
+        assert unit.afc.active_led_effects == []
 
 
 # ── lane_* -> _trigger_led_state suffix wiring ────────────────────────────────

--- a/tests/test_AFC_vivid.py
+++ b/tests/test_AFC_vivid.py
@@ -440,6 +440,13 @@ class TestCalibrateLane:
         unit.calibrate_lane(lane, 5.0)
         unit.eject_lane.assert_called_once_with(lane)
 
+    def test_calls_lane_not_ready(self):
+        unit = _make_vivid()
+        lane = MagicMock()
+        unit.eject_lane = MagicMock()
+        unit.calibrate_lane(lane, 0)
+        lane.unit_obj.lane_not_ready.assert_called_once_with(lane)
+
 
 # ── _get_selector_enabled except branch ───────────────────────────────────────
 

--- a/tests/test_AFC_vivid.py
+++ b/tests/test_AFC_vivid.py
@@ -440,12 +440,12 @@ class TestCalibrateLane:
         unit.calibrate_lane(lane, 5.0)
         unit.eject_lane.assert_called_once_with(lane)
 
-    def test_calls_lane_not_ready(self):
+    def test_calls_lane_unloaded(self):
         unit = _make_vivid()
         lane = MagicMock()
         unit.eject_lane = MagicMock()
         unit.calibrate_lane(lane, 0)
-        lane.unit_obj.lane_not_ready.assert_called_once_with(lane)
+        lane.unit_obj.lane_unloaded.assert_called_once_with(lane)
 
 
 # ── _get_selector_enabled except branch ───────────────────────────────────────


### PR DESCRIPTION
## Major Changes in this PR
- Added ability to call led effects when setting led colors during led transition states with `SET_LED_EFFECT EFFECT=<lane/extruder_name>_<effect_name>`, changes originally started with `trev1ak`
- Added ability to remember which last led state was set so the same led effect is not set again which can cause the effect to start over.
- Added new led method `lane_tool_loaded_gears` so that led effect can be applied when loading filament to nozzle.
- Moved turning off spools illumination to lane_not_ready method
- Added/fixed unit tests with the help from clause

Minor/Housekeeping changes
- Changed some led sets to use unit led methods so code sets leds all the same way
- Changed some `lane_unloaded` calls to `lane_not_ready` where it made sense when neither prep/load sensors are triggered
- Updating wording for PR template and PR rules in Agents.md file

## Notes to Code Reviewers
Documentation PR https://github.com/AFCProject/Documentation/pull/27

## How the changes in this PR are tested
On U1 toolchanger, the following are effects from `templates/led_effects_examples.cfg` examples

https://github.com/user-attachments/assets/066fb487-b0c2-46c6-9a2f-f979d99e3161


## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [x] Documentation updated in AT-Documentation repository
- [x] Sent notification to pr-review channel requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added animated LED effects for lane, extruder, loading, unloading, fault, and spool states.
  * Improved LED coordination and avoided unnecessary status updates.
  * Added more accurate lane lifecycle and tool-selection status handling.
* **Bug Fixes**
  * Corrected lane readiness, unloading, fault, and spool illumination indicators across supported hardware.
  * Improved extruder activation after tool unselection.
* **Documentation**
  * Added configuration examples and changelog details for the updated LED behavior.
* **Tests**
  * Expanded coverage for LED effects, lane transitions, loading, faults, recovery, and tool changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->