### PR TITLE
VIP (feat): Add virtual toolhead sensor for standalone toolheads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - New `pin_tool_start: virtual` option for `[AFC_extruder]` sections: creates a virtual
-  toolhead sensor for standalone toolchanger toolheads that have no physical sensor.
-  Filament presence is assumed, so standalone lanes no longer fail tool loads with
-  "Please load lane before continuing" (closes #810).
+  toolhead sensor for standalone toolchanger toolheads that have no physical sensor
+  (closes #810). The sensor starts unloaded and disabled; the GUI switch
+  (`SET_FILAMENT_SENSOR ENABLE=`) toggles filament presence, mirroring the virtual bypass.
+  The state persists in the vars file and is restored during PREP, and load/unload
+  sequences sync the switch with their result, so standalone lanes no longer fail tool
+  loads with "Please load lane before continuing" once the sensor is enabled.
 
 ## [09-10-2026]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,18 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2026-09-12]
 ### Added
-- New `pin_tool_start: virtual` option for `[AFC_extruder]` sections: creates a virtual
-  toolhead sensor for standalone toolchanger toolheads that have no physical sensor
-  (closes #810). The sensor starts unloaded and disabled; the GUI switch
-  (`SET_FILAMENT_SENSOR ENABLE=`) toggles filament presence, mirroring the virtual bypass.
-  The state persists in the vars file and is restored during PREP, and load/unload
-  sequences sync the switch with their result, so standalone lanes no longer fail tool
-  loads with "Please load lane before continuing" once the sensor is enabled.
-  Feeder lanes loading into an extruder with a virtual tool_start sensor now move by
-  distance instead of homing to the nonexistent tool sensor, and TOOL_UNLOAD no longer
-  retries forever against the software-only sensor state.
+- New `pin_tool_start: virtual` option for `[AFC_extruder]` sections: creates a virtual toolhead sensor for standalone toolchanger toolheads that have no physical sensor (closes #810).
+- Added `standalone_auto_load_unload` variable to AFC and AFC_extruder configs so users can bypass the automated load for standalone lanes for both toolheads that have a sensor and virtual sensors. When this is disabled user will have to still manually load filament into the toolheads gears/hotend.
 
 ## [09-10-2026]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The state persists in the vars file and is restored during PREP, and load/unload
   sequences sync the switch with their result, so standalone lanes no longer fail tool
   loads with "Please load lane before continuing" once the sensor is enabled.
+  Feeder lanes loading into an extruder with a virtual tool_start sensor now move by
+  distance instead of homing to the nonexistent tool sensor, and TOOL_UNLOAD no longer
+  retries forever against the software-only sensor state.
 
 ## [09-10-2026]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- New `pin_tool_start: virtual` option for `[AFC_extruder]` sections: creates a virtual
+  toolhead sensor for standalone toolchanger toolheads that have no physical sensor.
+  Filament presence is assumed, so standalone lanes no longer fail tool loads with
+  "Please load lane before continuing" (closes #810).
+
 ## [09-10-2026]
 ### Fixed
 - Disabled ooze prevention by default, this was originally meant for toolchangers. But with a recent klipperscreen update, klipperscreen now sends tool number(T) when setting temperature for single toolhead printers and AFC does not set temp because this was defaulted as enabled.

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -1901,7 +1901,9 @@ class afc:
                     return False
             # Ensure filament reaches the toolhead.
             tool_attempts = 0
-            if cur_extruder.tool_start:
+            # A virtual tool_start sensor has no hardware to confirm against,
+            # the distance move above is the whole load
+            if cur_extruder.tool_start and cur_extruder.tool_start != "virtual":
                 while (not cur_lane.get_toolhead_pre_sensor_state()
                        or warn == AFCMoveWarning.WARN):
                     tool_attempts += 1
@@ -2339,9 +2341,12 @@ class afc:
                         self.move_e_pos( cur_extruder.tool_stn_unload * -1, cur_extruder.tool_unload_speed, "Sensor move", wait_tool=True)
 
                     self.function.log_toolhead_pos("Sensor move after ")
-                    # For "standalone" toolheads, break out of the loop since sensor will always
-                    # be triggered
-                    if cur_lane.extruder_obj.is_standalone():
+                    # For "standalone" toolheads or extruders with a virtual tool_start
+                    # sensor, break out of the loop since the sensor will always stay
+                    # triggered: it is software-only state, there is nothing physical
+                    # to confirm the unload against
+                    if (cur_lane.extruder_obj.is_standalone()
+                            or cur_lane.extruder_obj.tool_start == "virtual"):
                         break
 
             self.afcDeltaTime.log_with_time("Unloaded from toolhead")

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -301,6 +301,7 @@ class afc:
         self.enable_tool_runout     = config.getboolean("enable_tool_runout",   True)
         self.enable_runout_in_bypass = config.getboolean("enable_runout_in_bypass", False)
         self.debounce_delay         = config.getfloat("debounce_delay",         0.)
+        self.standalone_auto_load_unload = config.getboolean("standalone_auto_load_unload", True)
 
         self.td1_when_loaded        = config.getboolean("capture_td1_when_loaded", False)
         self.debug                  = config.getboolean('debug', False)             # Setting to True turns on more debugging to show on console
@@ -1334,7 +1335,8 @@ class afc:
             str["system"]["extruders"][cur_extruder.name]={}
             str["system"]["extruders"][cur_extruder.name]['lane_loaded'] = cur_extruder.lane_loaded
             if getattr(cur_extruder, "tool_start", None) == "virtual":
-                str["system"]["extruders"][cur_extruder.name]['virtual_tool_start'] = bool(cur_extruder.tool_start_state)
+                extruder_entry = str["system"]["extruders"][cur_extruder.name]
+                extruder_entry['virtual_tool_start'] = bool(cur_extruder.tool_start_state)
 
         # Handing off to the background writer thread so a slow disk doesn't
         # block the reactor; queue.put_nowait never blocks the caller here
@@ -1536,6 +1538,7 @@ class afc:
         elif cur_lane.extruder_obj.is_standalone() and cur_lane.extruder_obj.lane_loaded:
             cur_lane.status = AFCLaneState.EJECTING
             cur_lane.extruder_obj.load_unload_sequence(cur_lane.extruder_obj.tool_stn_unload*-1)
+            self.save_vars()
 
         elif cur_lane.name == cur_lane.extruder_obj.lane_loaded:
             self.logger.warning(f"LANE {cur_lane.name} is loaded in toolhead, can't unload. "
@@ -1903,7 +1906,8 @@ class afc:
             tool_attempts = 0
             # A virtual tool_start sensor has no hardware to confirm against,
             # the distance move above is the whole load
-            if cur_extruder.tool_start and cur_extruder.tool_start != "virtual":
+            if (cur_extruder.tool_start
+                and cur_extruder.tool_start != "virtual"):
                 while (not cur_lane.get_toolhead_pre_sensor_state()
                        or warn == AFCMoveWarning.WARN):
                     tool_attempts += 1
@@ -2341,12 +2345,7 @@ class afc:
                         self.move_e_pos( cur_extruder.tool_stn_unload * -1, cur_extruder.tool_unload_speed, "Sensor move", wait_tool=True)
 
                     self.function.log_toolhead_pos("Sensor move after ")
-                    # For "standalone" toolheads or extruders with a virtual tool_start
-                    # sensor, break out of the loop since the sensor will always stay
-                    # triggered: it is software-only state, there is nothing physical
-                    # to confirm the unload against
-                    if (cur_lane.extruder_obj.is_standalone()
-                            or cur_lane.extruder_obj.tool_start == "virtual"):
+                    if cur_lane.extruder_obj.is_standalone():
                         break
 
             self.afcDeltaTime.log_with_time("Unloaded from toolhead")

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -1333,6 +1333,8 @@ class afc:
             cur_extruder = self.tools[extrude]
             str["system"]["extruders"][cur_extruder.name]={}
             str["system"]["extruders"][cur_extruder.name]['lane_loaded'] = cur_extruder.lane_loaded
+            if getattr(cur_extruder, "tool_start", None) == "virtual":
+                str["system"]["extruders"][cur_extruder.name]['virtual_tool_start'] = bool(cur_extruder.tool_start_state)
 
         # Handing off to the background writer thread so a slow disk doesn't
         # block the reactor; queue.put_nowait never blocks the caller here

--- a/extras/AFC_extruder.py
+++ b/extras/AFC_extruder.py
@@ -296,13 +296,14 @@ class AFCExtruder:
                 self.logger.info("Setting up as buffer")
             elif self.tool_start == "virtual":
                 # Virtual toolhead sensor for toolheads without a physical sensor (standalone
-                # toolchanger lanes). Filament presence is assumed and tracked in software only.
+                # toolchanger lanes). The sensor starts unloaded and disabled; the GUI switch
+                # (SET_FILAMENT_SENSOR ENABLE=) is the filament-presence state, mirroring how
+                # the virtual bypass works. The state is persisted in the vars file and restored
+                # during PREP.
                 self.fila_tool_start = VirtualFilamentSensor(
                     self.printer, f"{self.name}_tool_start", self.logger,
                     show_in_gui=self.enable_sensors_in_gui,
-                    runout_cb=self.handle_start_runout, enable_runout=self.enable_runout)
-                self.fila_tool_start.runout_helper.note_filament_present(is_filament_present=True)
-                self.tool_start_state = True
+                    enable_cb=self._virtual_tool_start_toggle)
             else:
                 self.fila_tool_start, self.debounce_button_start = add_filament_switch(f"{self.name}_tool_start", self.tool_start, self.printer,
                                                                                     self.enable_sensors_in_gui, self.handle_start_runout, self.enable_runout,
@@ -612,6 +613,66 @@ class AFCExtruder:
 
         self.tool_start_state = state
 
+    def _apply_virtual_tool_start_state(self, enabled: bool) -> None:
+        """
+        Shared bookkeeping for the virtual tool_start sensor state.
+
+        Keeps the sensor flags (`sensor_enabled`/`filament_present`), `tool_start_state`
+        and the standalone lane's loaded state in sync. Filament presence is assigned
+        directly instead of going through `note_filament_present` so toggling the switch
+        is purely bookkeeping and can never fire a runout.
+
+        :param enabled: New filament-present state for the virtual sensor.
+        """
+        enabled = bool(enabled)
+        helper = self.fila_tool_start.runout_helper
+        helper.sensor_enabled = enabled
+        helper.filament_present = enabled
+        self.tool_start_state = enabled
+
+        if self.tc_unit_name and self.is_standalone():
+            lane = self.tc_lane
+            lane._load_state = lane.prep_state = enabled
+            if enabled:
+                lane.set_tool_loaded()
+                lane.set_loaded()
+            else:
+                lane.set_tool_unloaded()
+                lane.set_unloaded()
+
+    def _virtual_tool_start_toggle(self, enabled: bool) -> None:
+        """
+        Callback for the virtual tool_start sensor's GUI switch (SET_FILAMENT_SENSOR
+        ENABLE=). The switch state is the filament-present state, so toggling it only
+        updates bookkeeping; no hardware is read and no load/unload sequence runs.
+
+        :param enabled: New ENABLE value from SET_FILAMENT_SENSOR.
+        """
+        enabled = bool(enabled)
+        if enabled == self.tool_start_state:
+            return
+
+        self._apply_virtual_tool_start_state(enabled)
+        self.logger.info(f"Virtual toolhead sensor for {self.name} "
+                         f"{'enabled, filament loaded' if enabled else 'disabled, filament unloaded'}")
+        if self.afc.prep_done:
+            self.afc.save_vars()
+
+    def restore_virtual_tool_start(self, enabled: bool) -> None:
+        """
+        Restore the virtual tool_start sensor state from the vars file during PREP,
+        same pattern as the virtual bypass restore.
+
+        :param enabled: Persisted filament-present state, defaults to False on a
+                        fresh install.
+        """
+        enabled = bool(enabled)
+        if enabled == self.tool_start_state:
+            return
+
+        self._apply_virtual_tool_start_state(enabled)
+        self.logger.info(f"Virtual toolhead sensor for {self.name} restored as "
+                         f"{'enabled, filament loaded' if enabled else 'disabled'}")
 
     def buffer_trailing_callback(self, eventtime, state):
         self.buffer_trailing = state
@@ -775,15 +836,21 @@ class AFCExtruder:
 
         if (current_temp >= target_temp - self.afc.temp_wait_tolerance
             and current_temp <= target_temp + self.afc.temp_wait_tolerance):
-            if self.tool_start_state:
+            # The virtual tool_start sensor has no hardware to confirm filament, so a
+            # load/unload sequence in progress is what defines its state
+            if self.tool_start_state or self.tool_start == "virtual":
                 info_str = "loading to" if self.current_move_distance > 0 else "unloading from"
                 self.logger.info(f"{self.th_extruder_name} temp within range, {info_str} nozzle")
                 self.move_extruder(self.current_move_distance)
                 if self.current_move_distance > 0:
                     self.tc_lane.set_loaded()
                     self.tc_lane.set_tool_loaded()
+                    if self.tool_start == "virtual":
+                        self._apply_virtual_tool_start_state(True)
                 else:
                     self.tc_lane.set_tool_unloaded()
+                    if self.tool_start == "virtual":
+                        self._apply_virtual_tool_start_state(False)
             else:
                 self.load_active = False
                 self.tc_lane.set_unloaded()

--- a/extras/AFC_extruder.py
+++ b/extras/AFC_extruder.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
 try: from extras.AFC_utils import ERROR_STR
 except: raise error("Error when trying to import AFC_utils.ERROR_STR\n{trace}".format(trace=traceback.format_exc()))
 
-try: from extras.AFC_utils import add_filament_switch
+try: from extras.AFC_utils import add_filament_switch, VirtualFilamentSensor
 except: raise error(ERROR_STR.format(import_lib="AFC_utils", trace=traceback.format_exc()))
 
 try: from extras.AFC_lane import AFCLane, AFCU1Lane
@@ -294,6 +294,15 @@ class AFCExtruder:
 
             if self.tool_start == "buffer":
                 self.logger.info("Setting up as buffer")
+            elif self.tool_start == "virtual":
+                # Virtual toolhead sensor for toolheads without a physical sensor (standalone
+                # toolchanger lanes). Filament presence is assumed and tracked in software only.
+                self.fila_tool_start = VirtualFilamentSensor(
+                    self.printer, f"{self.name}_tool_start", self.logger,
+                    show_in_gui=self.enable_sensors_in_gui,
+                    runout_cb=self.handle_start_runout, enable_runout=self.enable_runout)
+                self.fila_tool_start.runout_helper.note_filament_present(is_filament_present=True)
+                self.tool_start_state = True
             else:
                 self.fila_tool_start, self.debounce_button_start = add_filament_switch(f"{self.name}_tool_start", self.tool_start, self.printer,
                                                                                     self.enable_sensors_in_gui, self.handle_start_runout, self.enable_runout,

--- a/extras/AFC_extruder.py
+++ b/extras/AFC_extruder.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
     from extras.AFC_functions import afcFunction
     from extras.AFC_utils import AFC_moonraker
     from extras.AFC_lane import AFCLane
+    from extras.filament_switch_sensor import SwitchSensor
 
 try: from extras.AFC_utils import ERROR_STR
 except: raise error("Error when trying to import AFC_utils.ERROR_STR\n{trace}".format(trace=traceback.format_exc()))
@@ -291,6 +292,7 @@ class AFCExtruder:
         self.park_detector_obj   = None
 
         self.tool_start_state = False
+        self.fila_tool_start: SwitchSensor|VirtualFilamentSensor|None=None
         if self.tool_start is not None:
             if "unknown" == self.tool_start.lower():
                 raise error(f"Unknown is not valid for pin_tool_start in [{self.fullname}] config.")

--- a/extras/AFC_extruder.py
+++ b/extras/AFC_extruder.py
@@ -424,8 +424,8 @@ class AFCExtruder:
             self.tc_lane._load_state = self.tc_lane.prep_state = self.tool_start_state
 
             if self.tool_start_state:
-                self.tc_lane.set_tool_loaded()
                 self.tc_lane.set_loaded()
+                self.tc_lane.set_tool_loaded()
 
             if self.tool_start == "buffer":
                 error_msg = (
@@ -638,8 +638,10 @@ class AFCExtruder:
         lane = self.tc_lane
         if lane is None: return
         if enabled:
-            lane.set_tool_loaded()
             lane.set_loaded()
+            lane.set_tool_loaded()
+            if not self.on_shuttle():
+                lane.unit_obj.lane_tool_loaded_idle(lane)
         else:
             lane.set_tool_unloaded()
             if self.tool_start == "virtual":

--- a/extras/AFC_extruder.py
+++ b/extras/AFC_extruder.py
@@ -276,7 +276,10 @@ class AFCExtruder:
         self.no_lanes                   = False
         self.custom_tool_swap: Optional[str] = config.get("custom_tool_swap", None)
         self.custom_unselect: Optional[str] = config.get("custom_unselect", None)
-        self.enable_standalone_purge: bool  = config.getboolean("enable_standalone_purge", self.afc.enable_standalone_purge)
+        self.enable_standalone_purge: bool  = config.getboolean("enable_standalone_purge",
+                                                                self.afc.enable_standalone_purge)
+        self.standalone_auto_load_unload: bool  = config.getboolean("standalone_auto_load_unload",
+                                                                    self.afc.standalone_auto_load_unload)
 
         self.lane_loaded: Optional[str] = None
         self.lanes: Dict                = {}
@@ -296,14 +299,12 @@ class AFCExtruder:
                 self.logger.info("Setting up as buffer")
             elif self.tool_start == "virtual":
                 # Virtual toolhead sensor for toolheads without a physical sensor (standalone
-                # toolchanger lanes). The sensor starts unloaded and disabled; the GUI switch
-                # (SET_FILAMENT_SENSOR ENABLE=) is the filament-presence state, mirroring how
-                # the virtual bypass works. The state is persisted in the vars file and restored
-                # during PREP.
-                self.fila_tool_start = VirtualFilamentSensor(
-                    self.printer, f"{self.name}_tool_start", self.logger,
-                    show_in_gui=self.enable_sensors_in_gui,
-                    enable_cb=self._virtual_tool_start_toggle)
+                # toolchanger lanes only)
+                self.fila_tool_start = VirtualFilamentSensor(self.printer,
+                                                             f"{self.name}_tool_start", self.logger,
+                                                             show_in_gui=self.enable_sensors_in_gui,
+                                                             enable_cb=self._virtual_tool_start_toggle)
+                self.orig_note_filament_present = self.fila_tool_start.runout_helper.note_filament_present
             else:
                 self.fila_tool_start, self.debounce_button_start = add_filament_switch(f"{self.name}_tool_start", self.tool_start, self.printer,
                                                                                     self.enable_sensors_in_gui, self.handle_start_runout, self.enable_runout,
@@ -425,9 +426,18 @@ class AFCExtruder:
                 self.tc_lane.set_loaded()
 
             if self.tool_start == "buffer":
-                raise error(
-                    f"buffer is not valid config for pin_tool_start when using {self.name} as a standalone extruder"
+                error_msg = (
+                    f"buffer is not valid config for pin_tool_start when using {self.name} "
+                    "as a standalone extruder"
                 )
+                raise error(error_msg)
+        else:
+            if self.tool_start == "virtual":
+                error_msg = (
+                    f"{self.fullname} config section cannot have a virtual toolhead sensor when "
+                    "lanes are configured for this toolhead."
+                )
+                raise error(error_msg)
 
     def handle_connect(self):
         """
@@ -613,6 +623,26 @@ class AFCExtruder:
 
         self.tool_start_state = state
 
+    def _set_standalone_lane_states(self, enabled: bool) -> None:
+        """
+        Sync the standalone toolchanger lane's tool-loaded state with the extruder.
+
+        Marks the lane tool-loaded when enabled, or tool-unloaded when not. For a
+        virtual tool_start sensor, disabling also clears the lane back to fully
+        unloaded since there is no hardware sensor left holding it "prepped".
+
+        :param enabled: True to mark the lane loaded, False to mark it unloaded.
+        """
+        lane = self.tc_lane
+        if lane is None: return
+        if enabled:
+            lane.set_tool_loaded()
+            lane.set_loaded()
+        else:
+            lane.set_tool_unloaded()
+            if self.tool_start == "virtual":
+                lane.set_unloaded()
+
     def _apply_virtual_tool_start_state(self, enabled: bool) -> None:
         """
         Shared bookkeeping for the virtual tool_start sensor state.
@@ -624,37 +654,28 @@ class AFCExtruder:
 
         :param enabled: New filament-present state for the virtual sensor.
         """
+        if self.tool_start != "virtual": return
+
         enabled = bool(enabled)
         helper = self.fila_tool_start.runout_helper
         helper.sensor_enabled = enabled
         helper.filament_present = enabled
         self.tool_start_state = enabled
 
-        if self.tc_unit_name and self.is_standalone():
-            lane = self.tc_lane
-            lane._load_state = lane.prep_state = enabled
-            if enabled:
-                lane.set_tool_loaded()
-                lane.set_loaded()
-            else:
-                lane.set_tool_unloaded()
-                lane.set_unloaded()
-
     def _virtual_tool_start_toggle(self, enabled: bool) -> None:
         """
         Callback for the virtual tool_start sensor's GUI switch (SET_FILAMENT_SENSOR
-        ENABLE=). The switch state is the filament-present state, so toggling it only
-        updates bookkeeping; no hardware is read and no load/unload sequence runs.
+        ENABLE=). The switch state is the filament-present state; no hardware is read.
+        For a standalone extruder this routes through the normal tool_start_callback
+        auto load/unload chain (which owns persisting any resulting state change),
+        same as a real hardware sensor triggering.
 
         :param enabled: New ENABLE value from SET_FILAMENT_SENSOR.
         """
-        enabled = bool(enabled)
-        if enabled == self.tool_start_state:
-            return
-
+        self.note_tool_start_callback(enabled)
         self._apply_virtual_tool_start_state(enabled)
         self.logger.info(f"Virtual toolhead sensor for {self.name} "
-                         f"{'enabled, filament loaded' if enabled else 'disabled, filament unloaded'}")
+                         f"{'enabled.' if enabled else 'disabled'}")
         if self.afc.prep_done:
             self.afc.save_vars()
 
@@ -670,7 +691,12 @@ class AFCExtruder:
         if enabled == self.tool_start_state:
             return
 
+        if self.tc_lane is None:
+            return
+
         self._apply_virtual_tool_start_state(enabled)
+        self._set_standalone_lane_states(enabled)
+        self.tc_lane._load_state = self.tc_lane.prep_state = enabled
         self.logger.info(f"Virtual toolhead sensor for {self.name} restored as "
                          f"{'enabled, filament loaded' if enabled else 'disabled'}")
 
@@ -723,11 +749,27 @@ class AFCExtruder:
 
         This sequence has been setup so that this can happen during a print without causing TTC's
 
+        When `standalone_auto_load_unload` is disabled, the hotend is not heated and no filament is
+        moved; only the lane/extruder variables are updated to reflect the requested
+        load/unload state, as if the sequence had completed.
+
         :param distance: distance to load filament, this is set to `self.current_move_distance` so
                          that distance is saved and used in move_extruder function once extruder is
                          up to temperature
         """
         info_str = "Loading" if distance > 0 else "Unloading"
+        loaded = bool(distance > 0)
+
+        if not self.standalone_auto_load_unload:
+            self.tc_lane.status = AFCLaneState.TOOLED if loaded else AFCLaneState.NONE
+            self.tc_lane.need_purge = False
+            self._set_standalone_lane_states(loaded)
+            self._apply_virtual_tool_start_state(loaded)
+            self.logger.info(
+                f"{info_str} {self.name} skipped: standalone_auto_load_unload is disabled, "
+                "hotend heating and filament move were not performed")
+            return
+
         self.logger.info(f"{info_str} {self.name}")
         self.load_active = True
         self.current_move_distance = distance
@@ -836,21 +878,16 @@ class AFCExtruder:
 
         if (current_temp >= target_temp - self.afc.temp_wait_tolerance
             and current_temp <= target_temp + self.afc.temp_wait_tolerance):
-            # The virtual tool_start sensor has no hardware to confirm filament, so a
-            # load/unload sequence in progress is what defines its state
-            if self.tool_start_state or self.tool_start == "virtual":
+            if self.tool_start_state:
                 info_str = "loading to" if self.current_move_distance > 0 else "unloading from"
                 self.logger.info(f"{self.th_extruder_name} temp within range, {info_str} nozzle")
                 self.move_extruder(self.current_move_distance)
-                if self.current_move_distance > 0:
-                    self.tc_lane.set_loaded()
-                    self.tc_lane.set_tool_loaded()
-                    if self.tool_start == "virtual":
-                        self._apply_virtual_tool_start_state(True)
-                else:
-                    self.tc_lane.set_tool_unloaded()
-                    if self.tool_start == "virtual":
-                        self._apply_virtual_tool_start_state(False)
+                loaded = bool(self.current_move_distance > 0)
+
+                self._set_standalone_lane_states(loaded)
+                self._apply_virtual_tool_start_state(loaded)
+                if self.tool_start == "virtual":
+                    self.tc_lane._load_state = self.tc_lane.prep_state = loaded
             else:
                 self.load_active = False
                 self.tc_lane.set_unloaded()

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -948,6 +948,15 @@ class AFCLane:
                   True, 0, AFCMoveWarning.NONE.
         """
         warn = AFCMoveWarning.NONE
+        # A virtual tool_start sensor has no hardware to home against; when a
+        # feeder lane targets the tool sensor, fall back to a plain distance
+        # move so the commanded distance defines the load/unload
+        if (use_homing
+                and endstop is not None
+                and str(endstop) in (AFCHomingPoints.TOOL, AFCHomingPoints.TOOL_START)
+                and self.extruder_obj is not None
+                and self.extruder_obj.tool_start == "virtual"):
+            use_homing = False
         extruder_stepper = getattr(self, "extruder_stepper", None)
         drive_stepper_assist = None
         if (self.drive_stepper

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -319,7 +319,8 @@ class AFCLane:
             self._get_extruder_object()
             pin = self.extruder_obj.tool_start
             if (pin
-                and "buffer" not in pin):
+                and "buffer" not in pin
+                and pin.lower() != "virtual"):
                 self._set_homing_endstop(query_endstops, ppins,
                                          pin, AFCHomingPoints.TOOL)
 

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -948,15 +948,6 @@ class AFCLane:
                   True, 0, AFCMoveWarning.NONE.
         """
         warn = AFCMoveWarning.NONE
-        # A virtual tool_start sensor has no hardware to home against; when a
-        # feeder lane targets the tool sensor, fall back to a plain distance
-        # move so the commanded distance defines the load/unload
-        if (use_homing
-                and endstop is not None
-                and str(endstop) in (AFCHomingPoints.TOOL, AFCHomingPoints.TOOL_START)
-                and self.extruder_obj is not None
-                and self.extruder_obj.tool_start == "virtual"):
-            use_homing = False
         extruder_stepper = getattr(self, "extruder_stepper", None)
         drive_stepper_assist = None
         if (self.drive_stepper

--- a/extras/AFC_prep.py
+++ b/extras/AFC_prep.py
@@ -267,6 +267,17 @@ class afcPrep:
         if self.afc.bypass.filament_present:
             self.logger.raw(f"<span class=warning--text>{bypass_name} enabled</span>")
 
+        # Restore previous virtual tool_start sensor states (toolheads without a physical
+        # toolhead sensor), same vars-file pattern as the virtual bypass above
+        for extruder_obj in self.afc.tools.values():
+            if getattr(extruder_obj, "tool_start", None) == "virtual":
+                virt_state = False
+                if "system" in units and "extruders" in units["system"]:
+                    virt_state = bool(units["system"]["extruders"]
+                                      .get(extruder_obj.name, {})
+                                      .get("virtual_tool_start", False))
+                extruder_obj.restore_virtual_tool_start(virt_state)
+
         for extruder in self.afc.tools.values():
             extruder.estats.check_cut_threshold()
 

--- a/extras/AFC_prep.py
+++ b/extras/AFC_prep.py
@@ -140,6 +140,16 @@ class afcPrep:
                   units["system"]["extruders"][extruder_obj.name]['lane_loaded']:
                     extruder_obj.lane_loaded = units["system"]["extruders"][extruder_obj.name]['lane_loaded']
 
+            # Restore previous virtual tool_start sensor states (toolheads without a physical
+            # toolhead sensor), same vars-file pattern as the virtual bypass above
+            if getattr(extruder_obj, "tool_start", None) == "virtual":
+                virt_state = False
+                if "system" in units and "extruders" in units["system"]:
+                    virt_state = bool(units["system"]["extruders"]
+                                      .get(extruder_obj.name, {})
+                                      .get("virtual_tool_start", False))
+                extruder_obj.restore_virtual_tool_start(virt_state)
+
         self.afc.print_version(console_only=True)
         if self.afc.snapmaker_printer:
             self.logger.info("Snapmaker Printer Detected")
@@ -266,17 +276,6 @@ class afcPrep:
         # Add warning message so users know that either bypass or virtual bypass is enabled
         if self.afc.bypass.filament_present:
             self.logger.raw(f"<span class=warning--text>{bypass_name} enabled</span>")
-
-        # Restore previous virtual tool_start sensor states (toolheads without a physical
-        # toolhead sensor), same vars-file pattern as the virtual bypass above
-        for extruder_obj in self.afc.tools.values():
-            if getattr(extruder_obj, "tool_start", None) == "virtual":
-                virt_state = False
-                if "system" in units and "extruders" in units["system"]:
-                    virt_state = bool(units["system"]["extruders"]
-                                      .get(extruder_obj.name, {})
-                                      .get("virtual_tool_start", False))
-                extruder_obj.restore_virtual_tool_start(virt_state)
 
         for extruder in self.afc.tools.values():
             extruder.estats.check_cut_threshold()

--- a/extras/AFC_stepper.py
+++ b/extras/AFC_stepper.py
@@ -570,7 +570,10 @@ class AFCExtruderStepper(AFCLane):
         if (hub_pin
             and hub_pin.lower() != "virtual"):
             self._add_endstop('hub', hub_pin, 'hub')
-        if tool_start_pin != 'buffer':
+        if tool_start_pin is not None and tool_start_pin.lower() == "virtual":
+            # Virtual toolhead sensor: no hardware pin to register an endstop for
+            pass
+        elif tool_start_pin != 'buffer':
             self._add_endstop('tool_start', tool_start_pin, 'tool_start')
         else:
             if buffer_adv_pin is not None:

--- a/extras/AFC_stepper.py
+++ b/extras/AFC_stepper.py
@@ -570,7 +570,8 @@ class AFCExtruderStepper(AFCLane):
         if (hub_pin
             and hub_pin.lower() != "virtual"):
             self._add_endstop('hub', hub_pin, 'hub')
-        if tool_start_pin is not None and tool_start_pin.lower() == "virtual":
+        if (tool_start_pin is not None
+            and tool_start_pin.lower() == "virtual"):
             # Virtual toolhead sensor: no hardware pin to register an endstop for
             pass
         elif tool_start_pin != 'buffer':

--- a/extras/AFC_utils.py
+++ b/extras/AFC_utils.py
@@ -305,7 +305,8 @@ class VirtualFilamentSensor:
 
     def __init__(self, printer: Printer, name: str, logger: AFC_logger,
                 show_in_gui: bool = True, runout_cb: Optional[Callable] = None,
-                enable_runout: bool = False) -> None:
+                enable_runout: bool = False,
+                enable_cb: Optional[Callable] = None) -> None:
         """
         Register a lightweight virtual filament sensor.
 
@@ -318,10 +319,14 @@ class VirtualFilamentSensor:
         :param show_in_gui: When False, hide the sensor from the GUI.
         :param runout_cb: Optional runout callback passed to the runout helper.
         :param enable_runout: Whether runout callbacks are enabled.
+        :param enable_cb: Optional callback invoked with the new ENABLE value whenever
+                          SET_FILAMENT_SENSOR toggles this sensor, allowing callers to
+                          treat the GUI switch as the filament-presence state.
         """
         self.printer: Printer = printer
         self.name: str = name
         self.logger: AFC_logger = logger
+        self.enable_cb: Optional[Callable] = enable_cb
         self._object_name: str = f"filament_switch_sensor {name}"
         self._object_name = self._object_name if show_in_gui else "_" + self._object_name
         self.runout_helper: VirtualRunoutHelper = VirtualRunoutHelper(
@@ -381,7 +386,10 @@ class VirtualFilamentSensor:
 
         :param gcmd: The parsed G-code command.
         """
-        self.runout_helper.sensor_enabled = bool(gcmd.get_int("ENABLE", 1, minval=0, maxval=1))
+        enable = bool(gcmd.get_int("ENABLE", 1, minval=0, maxval=1))
+        self.runout_helper.sensor_enabled = enable
+        if self.enable_cb is not None:
+            self.enable_cb(enable)
 
 class AFC_moonraker:
     """

--- a/tests/test_AFC.py
+++ b/tests/test_AFC.py
@@ -3719,6 +3719,44 @@ class TestLoadSequenceDefaultPathSuccess:
         lane.unit_obj.lane_tool_loaded_gears.assert_called_once_with(lane)
 
 
+class TestLoadSequenceToolStartVirtualSkip:
+    """Covers the `cur_extruder.tool_start != "virtual"` guard on the pre-extruder
+    sensor retry loop, distinct from TestLoadSequenceDefaultPathSuccess where the
+    sensor already reports True and never exercises the loop either way."""
+
+    def _make(self, tool_start):
+        afc, lane, hub, extruder = TestLoadSequenceDefaultPathSuccess()._make()
+        extruder.tool_start = tool_start
+        afc.home_to_tool = False
+        afc.tool_homing_distance = 200
+        lane.short_move_dis = 10
+        # Sensor never confirms filament, so the retry loop -- if entered at
+        # all -- would keep calling move_to until the guard above skips it.
+        lane.get_toolhead_pre_sensor_state = MagicMock(side_effect=[False, True])
+        lane.move_to = MagicMock(return_value=(True, 10, AFCMoveWarning.NONE))
+        return afc, lane, hub, extruder
+
+    def test_virtual_tool_start_skips_retry_loop(self):
+        afc, lane, hub, extruder = self._make("virtual")
+        result = afc.load_sequence(lane, hub, extruder)
+        assert result is not False
+        lane.move_to.assert_not_called()
+
+    def test_no_tool_start_pin_skips_retry_loop(self):
+        """Covers the `cur_extruder.tool_start` guard's falsy branch (no
+        tool_start pin configured at all, e.g. a buffer-only setup)."""
+        afc, lane, hub, extruder = self._make(None)
+        result = afc.load_sequence(lane, hub, extruder)
+        assert result is not False
+        lane.move_to.assert_not_called()
+
+    def test_real_tool_start_pin_runs_retry_loop(self):
+        afc, lane, hub, extruder = self._make("^PD3")
+        result = afc.load_sequence(lane, hub, extruder)
+        assert result is not False
+        lane.move_to.assert_called_once()
+
+
 class TestToolLoadNeedPurge:
     def _make_afc_lane_for_need_purge(self, need_purge=True, check_extruder_temp_return=True,
                                       printing=False):
@@ -4648,6 +4686,53 @@ class TestSaveVars:
         with patch("builtins.open") as mock_open:
             obj.save_vars()
         mock_open.assert_not_called()
+
+
+class TestSaveVarsVirtualToolStart:
+    """Covers the `getattr(cur_extruder, "tool_start", None) == "virtual"` branch
+    that adds a `virtual_tool_start` entry to the persisted extruder snapshot."""
+
+    def test_virtual_sensor_adds_virtual_tool_start_key(self):
+        obj = _make_afc_for_save_vars(prep_done=True)
+        obj.tools["extruder"].tool_start = "virtual"
+        obj.tools["extruder"].tool_start_state = True
+
+        obj.save_vars()
+
+        data = obj._var_write_queue.put_nowait.call_args[0][0]
+        assert data["system"]["extruders"]["extruder"]["virtual_tool_start"] is True
+
+    def test_virtual_sensor_state_false(self):
+        """Covers `bool(cur_extruder.tool_start_state)` with a falsy state."""
+        obj = _make_afc_for_save_vars(prep_done=True)
+        obj.tools["extruder"].tool_start = "virtual"
+        obj.tools["extruder"].tool_start_state = False
+
+        obj.save_vars()
+
+        data = obj._var_write_queue.put_nowait.call_args[0][0]
+        assert data["system"]["extruders"]["extruder"]["virtual_tool_start"] is False
+
+    def test_non_virtual_sensor_omits_key(self):
+        """Covers the `== "virtual"` guard's False branch for a real hardware pin."""
+        obj = _make_afc_for_save_vars(prep_done=True)
+        obj.tools["extruder"].tool_start = "^PD3"
+
+        obj.save_vars()
+
+        data = obj._var_write_queue.put_nowait.call_args[0][0]
+        assert "virtual_tool_start" not in data["system"]["extruders"]["extruder"]
+
+    def test_missing_tool_start_attribute_omits_key(self):
+        """Covers the `getattr(..., None)` default for extruders with no
+        tool_start attribute at all."""
+        obj = _make_afc_for_save_vars(prep_done=True)
+        del obj.tools["extruder"].tool_start
+
+        obj.save_vars()
+
+        data = obj._var_write_queue.put_nowait.call_args[0][0]
+        assert "virtual_tool_start" not in data["system"]["extruders"]["extruder"]
 
 
 class TestWriteVarsSnapshot:

--- a/tests/test_AFC_extruder.py
+++ b/tests/test_AFC_extruder.py
@@ -289,6 +289,29 @@ def _make_afc_extruder_as_standalone(name="extruder", extruder_values=None, afc_
 
 # ── AFCExtruder.__str__ ────────────────────────────────────────────────────────
 
+# -- pin_tool_start: virtual -----------------------------------------------------
+
+class TestVirtualToolStart:
+    def test_virtual_tool_start_assumes_filament_loaded(self):
+        ext = _make_afc_extruder_as_standalone("extruder", extruder_values={"pin_tool_start": "virtual"})
+        assert ext.tool_start_state is True
+        assert ext.fila_tool_start is not None
+        assert ext.fila_tool_start.runout_helper.filament_present is True
+
+    def test_virtual_tool_start_registers_no_debounce_button(self):
+        ext = _make_afc_extruder_as_standalone("extruder", extruder_values={"pin_tool_start": "virtual"})
+        assert getattr(ext, "debounce_button_start", None) is None
+
+    def test_standalone_ready_keeps_lane_loaded_with_virtual_sensor(self):
+        ext = _make_afc_extruder_as_standalone(
+            "extruder", extruder_values={"pin_tool_start": "virtual"})
+        ext.lanes.update({"extruder": ext})
+        ext.tc_lane = _make_afc_lane()
+        ext.handle_ready()
+        assert ext.no_lanes is True
+        assert ext.tc_lane._load_state is True
+
+
 class TestAFCExtruderStr:
     def test_str_returns_name(self):
         ext = _make_afc_extruder("my_extruder")

--- a/tests/test_AFC_extruder.py
+++ b/tests/test_AFC_extruder.py
@@ -18,6 +18,7 @@ import types
 
 from extras.AFC_extruder import AFCExtruderStats, AFCExtruder
 from extras.AFC import State
+from tests.conftest import MockGCodeCommand
 from tests.test_AFC_lane import _make_afc_lane, AFCLaneState
 # ── Helpers ─────────────────────────────────────────────────────────
 
@@ -292,24 +293,140 @@ def _make_afc_extruder_as_standalone(name="extruder", extruder_values=None, afc_
 # -- pin_tool_start: virtual -----------------------------------------------------
 
 class TestVirtualToolStart:
-    def test_virtual_tool_start_assumes_filament_loaded(self):
-        ext = _make_afc_extruder_as_standalone("extruder", extruder_values={"pin_tool_start": "virtual"})
-        assert ext.tool_start_state is True
-        assert ext.fila_tool_start is not None
-        assert ext.fila_tool_start.runout_helper.filament_present is True
-
-    def test_virtual_tool_start_registers_no_debounce_button(self):
-        ext = _make_afc_extruder_as_standalone("extruder", extruder_values={"pin_tool_start": "virtual"})
-        assert getattr(ext, "debounce_button_start", None) is None
-
-    def test_standalone_ready_keeps_lane_loaded_with_virtual_sensor(self):
-        ext = _make_afc_extruder_as_standalone(
+    def _make_virtual_extruder(self):
+        return _make_afc_extruder_as_standalone(
             "extruder", extruder_values={"pin_tool_start": "virtual"})
+
+    def _make_standalone_virtual(self):
+        """Virtual-sensor extruder wired like a standalone toolchanger lane."""
+        ext = self._make_virtual_extruder()
         ext.lanes.update({"extruder": ext})
+        ext.tc_unit_name = "AFC_Toolchanger tc"
         ext.tc_lane = _make_afc_lane()
+        ext.tc_lane.extruder_obj = ext
         ext.handle_ready()
         assert ext.no_lanes is True
+        return ext
+
+    def test_virtual_tool_start_starts_unloaded_and_disabled(self):
+        ext = self._make_virtual_extruder()
+        assert ext.tool_start_state is False
+        assert ext.fila_tool_start is not None
+        helper = ext.fila_tool_start.runout_helper
+        assert helper.filament_present is False
+        assert helper.sensor_enabled is False
+
+    def test_virtual_tool_start_registers_no_debounce_button(self):
+        ext = self._make_virtual_extruder()
+        assert getattr(ext, "debounce_button_start", None) is None
+
+    def test_virtual_tool_start_wires_enable_callback(self):
+        ext = self._make_virtual_extruder()
+        assert ext.fila_tool_start.enable_cb == ext._virtual_tool_start_toggle
+
+    def test_standalone_ready_keeps_lane_unloaded_with_virtual_sensor(self):
+        ext = self._make_standalone_virtual()
+        assert ext.tc_lane._load_state is False
+        assert ext.tc_lane.prep_state is False
+
+    def test_set_filament_sensor_enable_loads_lane(self):
+        ext = self._make_standalone_virtual()
+        ext.afc.prep_done = True
+        ext.afc.save_vars = MagicMock()
+
+        ext.fila_tool_start.cmd_SET_FILAMENT_SENSOR(MockGCodeCommand(params={"ENABLE": 1}))
+
+        assert ext.tool_start_state is True
+        helper = ext.fila_tool_start.runout_helper
+        assert helper.sensor_enabled is True
+        assert helper.filament_present is True
         assert ext.tc_lane._load_state is True
+        assert ext.tc_lane.prep_state is True
+        assert ext.tc_lane.extruder_obj.lane_loaded == ext.tc_lane.name
+        ext.afc.save_vars.assert_called_once()
+
+    def test_set_filament_sensor_disable_unloads_lane(self):
+        ext = self._make_standalone_virtual()
+        ext.restore_virtual_tool_start(True)
+
+        ext.fila_tool_start.cmd_SET_FILAMENT_SENSOR(MockGCodeCommand(params={"ENABLE": 0}))
+
+        assert ext.tool_start_state is False
+        helper = ext.fila_tool_start.runout_helper
+        assert helper.sensor_enabled is False
+        assert helper.filament_present is False
+        assert ext.tc_lane._load_state is False
+        assert ext.tc_lane.prep_state is False
+
+    def test_toggle_same_state_is_noop(self):
+        ext = self._make_standalone_virtual()
+        ext.afc.prep_done = True
+        ext.afc.save_vars = MagicMock()
+
+        ext.fila_tool_start.cmd_SET_FILAMENT_SENSOR(MockGCodeCommand(params={"ENABLE": 0}))
+
+        assert ext.tool_start_state is False
+        ext.afc.save_vars.assert_not_called()
+
+    def test_toggle_skips_save_vars_before_prep(self):
+        ext = self._make_standalone_virtual()
+        assert ext.afc.prep_done is False
+        ext.afc.save_vars = MagicMock()
+
+        ext.fila_tool_start.cmd_SET_FILAMENT_SENSOR(MockGCodeCommand(params={"ENABLE": 1}))
+
+        assert ext.tool_start_state is True
+        ext.afc.save_vars.assert_not_called()
+
+    def test_restore_from_vars_enables_sensor_and_lane(self):
+        ext = self._make_standalone_virtual()
+
+        ext.restore_virtual_tool_start(True)
+
+        assert ext.tool_start_state is True
+        assert ext.fila_tool_start.runout_helper.filament_present is True
+        assert ext.fila_tool_start.runout_helper.sensor_enabled is True
+        assert ext.tc_lane._load_state is True
+        assert ext.tc_lane.prep_state is True
+
+    def test_restore_defaults_to_disabled_noop(self):
+        ext = self._make_standalone_virtual()
+
+        ext.restore_virtual_tool_start(False)
+
+        assert ext.tool_start_state is False
+        assert ext.tc_lane._load_state is False
+
+    def test_temp_check_cb_load_completes_and_syncs_virtual_sensor(self):
+        ext = self._make_standalone_virtual()
+        heater = MagicMock()
+        heater.get_temp.return_value = (200.0, 200.0)
+        ext.get_heater = MagicMock(return_value=heater)
+        ext.move_extruder = MagicMock()
+        ext.current_move_distance = 72.0
+
+        ret = ext.temp_check_cb(0.0)
+
+        assert ret == ext.reactor.NEVER
+        ext.move_extruder.assert_called_once_with(72.0)
+        assert ext.tool_start_state is True
+        assert ext.fila_tool_start.runout_helper.filament_present is True
+        assert ext.tc_lane._load_state is True
+
+    def test_temp_check_cb_unload_clears_virtual_sensor(self):
+        ext = self._make_standalone_virtual()
+        ext.restore_virtual_tool_start(True)
+        heater = MagicMock()
+        heater.get_temp.return_value = (200.0, 200.0)
+        ext.get_heater = MagicMock(return_value=heater)
+        ext.move_extruder = MagicMock()
+        ext.current_move_distance = -100.0
+
+        ext.temp_check_cb(0.0)
+
+        assert ext.tool_start_state is False
+        assert ext.fila_tool_start.runout_helper.filament_present is False
+        assert ext.tc_lane._load_state is False
 
 
 class TestAFCExtruderStr:
@@ -673,7 +790,6 @@ class TestCmdUpdateToolheadSensors:
         own default (gcmd.get_float(..., self.tool_stn) etc.), so there's no
         need to duplicate that fallback here -- ext is unused now but kept
         as a parameter so existing call sites don't need to change."""
-        from tests.conftest import MockGCodeCommand
         params = {}
         if tool_stn is not None:
             params["TOOL_STN"] = tool_stn

--- a/tests/test_AFC_extruder.py
+++ b/tests/test_AFC_extruder.py
@@ -1814,6 +1814,27 @@ class TestSetStandaloneLaneStates:
         ext.tc_lane.set_tool_unloaded.assert_not_called()
         ext.tc_lane.set_unloaded.assert_not_called()
 
+    def test_enabled_not_on_shuttle_calls_lane_tool_loaded_idle(self):
+        """Covers the `not self.on_shuttle()` guard's True branch."""
+        ext = self._make()
+        ext.on_shuttle = MagicMock(return_value=False)
+        ext._set_standalone_lane_states(True)
+        ext.tc_lane.unit_obj.lane_tool_loaded_idle.assert_called_once_with(ext.tc_lane)
+
+    def test_enabled_on_shuttle_skips_lane_tool_loaded_idle(self):
+        """Covers the `not self.on_shuttle()` guard's False branch."""
+        ext = self._make()
+        ext.on_shuttle = MagicMock(return_value=True)
+        ext._set_standalone_lane_states(True)
+        ext.tc_lane.unit_obj.lane_tool_loaded_idle.assert_not_called()
+
+    def test_disabled_does_not_call_lane_tool_loaded_idle(self):
+        """The on_shuttle/idle-led check only runs on the enabled path."""
+        ext = self._make(tool_start="virtual")
+        ext.on_shuttle = MagicMock(return_value=False)
+        ext._set_standalone_lane_states(False)
+        ext.tc_lane.unit_obj.lane_tool_loaded_idle.assert_not_called()
+
     def test_disabled_real_sensor_calls_set_tool_unloaded_only(self):
         """Covers the `self.tool_start == "virtual"` guard's False branch."""
         ext = self._make(tool_start="^PD3")

--- a/tests/test_AFC_extruder.py
+++ b/tests/test_AFC_extruder.py
@@ -294,8 +294,13 @@ def _make_afc_extruder_as_standalone(name="extruder", extruder_values=None, afc_
 
 class TestVirtualToolStart:
     def _make_virtual_extruder(self):
+        # A virtual tool_start sensor means there is no physical AFC feeder at this
+        # toolhead -- the GUI switch is the whole state, so standalone_auto_load_unload
+        # is disabled: the state-toggle path completes synchronously instead of trying
+        # to heat/move filament that no hardware will ever act on.
         return _make_afc_extruder_as_standalone(
-            "extruder", extruder_values={"pin_tool_start": "virtual"})
+            "extruder", extruder_values={"pin_tool_start": "virtual",
+                                         "standalone_auto_load_unload": False})
 
     def _make_standalone_virtual(self):
         """Virtual-sensor extruder wired like a standalone toolchanger lane."""
@@ -304,6 +309,14 @@ class TestVirtualToolStart:
         ext.tc_unit_name = "AFC_Toolchanger tc"
         ext.tc_lane = _make_afc_lane()
         ext.tc_lane.extruder_obj = ext
+        # PREP has already run and no print is active, so tool_start_callback's auto
+        # load/unload logic engages instead of being a no-op for the sensor-toggle
+        # tests below. afc.function is a bare MagicMock here (a real afc's function
+        # section isn't loaded by MockPrinter), so is_printing() must be pinned down
+        # -- otherwise it returns a truthy Mock and actively_printing short-circuits
+        # the load/unload path for every one of these tests.
+        ext.tc_lane._afc_prep_done = True
+        ext.afc.function.is_printing.return_value = False
         ext.handle_ready()
         assert ext.no_lanes is True
         return ext
@@ -343,7 +356,9 @@ class TestVirtualToolStart:
         assert ext.tc_lane._load_state is True
         assert ext.tc_lane.prep_state is True
         assert ext.tc_lane.extruder_obj.lane_loaded == ext.tc_lane.name
-        ext.afc.save_vars.assert_called_once()
+        # Saved twice: once by tool_start_callback's own auto-load-triggered save,
+        # once more by _virtual_tool_start_toggle's own `if self.afc.prep_done` save.
+        assert ext.afc.save_vars.call_count == 2
 
     def test_set_filament_sensor_disable_unloads_lane(self):
         ext = self._make_standalone_virtual()
@@ -358,7 +373,10 @@ class TestVirtualToolStart:
         assert ext.tc_lane._load_state is False
         assert ext.tc_lane.prep_state is False
 
-    def test_toggle_same_state_is_noop(self):
+    def test_toggle_same_state_is_noop_for_tool_start_callback(self):
+        """tool_start_callback itself is a no-op when the sensor state doesn't
+        change (no auto load/unload triggered), but _virtual_tool_start_toggle
+        still persists once on its own since afc.prep_done is True here."""
         ext = self._make_standalone_virtual()
         ext.afc.prep_done = True
         ext.afc.save_vars = MagicMock()
@@ -366,11 +384,15 @@ class TestVirtualToolStart:
         ext.fila_tool_start.cmd_SET_FILAMENT_SENSOR(MockGCodeCommand(params={"ENABLE": 0}))
 
         assert ext.tool_start_state is False
-        ext.afc.save_vars.assert_not_called()
+        ext.afc.save_vars.assert_called_once()
 
-    def test_toggle_skips_save_vars_before_prep(self):
+    def test_toggle_skips_save_vars_before_lane_prep_done(self):
+        """tool_start_callback (reached via the toggle) gates its whole
+        auto load/unload chain -- save_vars included -- on the lane's own
+        _afc_prep_done, not the global afc.prep_done. Before that lane's
+        prep has completed, toggling the switch is pure bookkeeping."""
         ext = self._make_standalone_virtual()
-        assert ext.afc.prep_done is False
+        ext.tc_lane._afc_prep_done = False
         ext.afc.save_vars = MagicMock()
 
         ext.fila_tool_start.cmd_SET_FILAMENT_SENSOR(MockGCodeCommand(params={"ENABLE": 1}))
@@ -399,6 +421,9 @@ class TestVirtualToolStart:
 
     def test_temp_check_cb_load_completes_and_syncs_virtual_sensor(self):
         ext = self._make_standalone_virtual()
+        # A load is in progress: the switch was already toggled on (tool_start_state
+        # True), and temp_check_cb is now firing once the hotend reaches temp.
+        ext.tool_start_state = True
         heater = MagicMock()
         heater.get_temp.return_value = (200.0, 200.0)
         ext.get_heater = MagicMock(return_value=heater)
@@ -1642,3 +1667,337 @@ class TestExtruderMoveCB:
         assert AFCLaneState.TOOLED == ext.tc_lane.status
         assert not ext.tc_lane.need_purge
         assert 0 == ext.current_move_distance
+
+
+# ── load_unload_sequence ───────────────────────────────────────────────────────
+
+class TestLoadUnloadSequence:
+    def _make(self, standalone_auto_load_unload=True, extruder_values=None):
+        values = {"toolchanger_unit": "Tools",
+                  "standalone_auto_load_unload": standalone_auto_load_unload}
+        values.update(extruder_values or {})
+        ext = _make_afc_extruder_as_standalone(extruder_values=values)
+        ext.afc.capture_toolhead_temp = MagicMock(return_value="captured")
+        ext.afc._check_extruder_temp = MagicMock()
+        ext.afc.save_vars = MagicMock()
+        ext.reactor.update_timer = MagicMock()
+        ext.tc_lane = _make_afc_lane(fullname="AFC_stepper extruder")
+        ext.tc_lane.unit_obj = MagicMock()
+        ext._set_standalone_lane_states = MagicMock()
+        ext._apply_virtual_tool_start_state = MagicMock()
+        return ext
+
+    def test_enabled_starts_heating(self):
+        ext = self._make(standalone_auto_load_unload=True)
+        ext.load_unload_sequence(100)
+        ext.afc._check_extruder_temp.assert_called_once_with(ext.tc_lane, no_wait=True)
+        ext.afc.capture_toolhead_temp.assert_called_once_with(extruder=ext, async_capture=True)
+        ext.reactor.update_timer.assert_called_once()
+
+    def test_enabled_sets_load_active_and_move_distance(self):
+        ext = self._make(standalone_auto_load_unload=True)
+        ext.load_unload_sequence(100)
+        assert ext.load_active is True
+        assert ext.current_move_distance == 100
+
+    def test_enabled_loading_sets_tool_loading_status_and_led(self):
+        ext = self._make(standalone_auto_load_unload=True)
+        ext.load_unload_sequence(100)
+        assert ext.tc_lane.status == AFCLaneState.TOOL_LOADING
+        ext.tc_lane.unit_obj.lane_loading.assert_called_once_with(ext.tc_lane)
+
+    def test_enabled_unloading_sets_tool_unloading_status(self):
+        ext = self._make(standalone_auto_load_unload=True)
+        ext.load_unload_sequence(-100)
+        assert ext.tc_lane.status == AFCLaneState.TOOL_UNLOADING
+        ext.tc_lane.unit_obj.lane_loading.assert_not_called()
+
+    def test_enabled_does_not_touch_bookkeeping_helpers(self):
+        """The skip-path bookkeeping (final status/need_purge/lane-state helpers)
+        is only for the disabled branch -- the enabled path leaves that to the
+        temp/move callbacks instead."""
+        ext = self._make(standalone_auto_load_unload=True)
+        ext.load_unload_sequence(100)
+        ext._set_standalone_lane_states.assert_not_called()
+        ext._apply_virtual_tool_start_state.assert_not_called()
+        ext.afc.save_vars.assert_not_called()
+
+    def test_disabled_does_not_start_heating_or_timer(self):
+        ext = self._make(standalone_auto_load_unload=False)
+        ext.load_unload_sequence(100)
+        ext.afc._check_extruder_temp.assert_not_called()
+        ext.afc.capture_toolhead_temp.assert_not_called()
+        ext.reactor.update_timer.assert_not_called()
+
+    def test_disabled_does_not_set_load_active_or_move_distance(self):
+        ext = self._make(standalone_auto_load_unload=False)
+        ext.load_unload_sequence(100)
+        assert ext.load_active is False
+        assert ext.current_move_distance == 0
+
+    def test_disabled_loading_sets_final_tooled_status(self):
+        ext = self._make(standalone_auto_load_unload=False)
+        ext.load_unload_sequence(100)
+        assert ext.tc_lane.status == AFCLaneState.TOOLED
+        ext.tc_lane.unit_obj.lane_loading.assert_not_called()
+        ext._set_standalone_lane_states.assert_called_once_with(True)
+        ext._apply_virtual_tool_start_state.assert_called_once_with(True)
+
+    def test_disabled_unloading_sets_final_none_status(self):
+        ext = self._make(standalone_auto_load_unload=False)
+        ext.load_unload_sequence(-100)
+        assert ext.tc_lane.status == AFCLaneState.NONE
+        ext._set_standalone_lane_states.assert_called_once_with(False)
+        ext._apply_virtual_tool_start_state.assert_called_once_with(False)
+
+    def test_disabled_clears_need_purge(self):
+        ext = self._make(standalone_auto_load_unload=False)
+        ext.tc_lane.need_purge = True
+        ext.load_unload_sequence(100)
+        assert ext.tc_lane.need_purge is False
+
+    def test_disabled_does_not_save_vars(self):
+        """Persisting is the caller's job (tool_start_callback / AFC.LANE_EJECT),
+        same as the enabled/heating path which only saves later via
+        extruder_move_cb -- load_unload_sequence itself never saves synchronously
+        for either branch."""
+        ext = self._make(standalone_auto_load_unload=False)
+        ext.load_unload_sequence(100)
+        ext.afc.save_vars.assert_not_called()
+
+    def test_disabled_logs_skip_message(self):
+        ext = self._make(standalone_auto_load_unload=False)
+        ext.load_unload_sequence(100)
+        info_msgs = [m for lvl, m in ext.logger.messages if lvl == "info"]
+        assert any("standalone_auto_load_unload is disabled" in m for m in info_msgs)
+        assert any("hotend heating and filament move were not performed" in m for m in info_msgs)
+
+    def test_default_config_value_is_enabled(self):
+        """standalone_auto_load_unload defaults to True (mirroring afc.standalone_auto_load_unload)
+        when not set in either the extruder or AFC config sections."""
+        ext = self._make(standalone_auto_load_unload=True)
+        assert ext.standalone_auto_load_unload is True
+
+    def test_falls_back_to_afc_level_default(self):
+        """Regression test: the config default expression must reference
+        afc.standalone_auto_load_unload (not the nonexistent afc.standalone_auto_load),
+        or constructing the extruder raises AttributeError."""
+        ext = _make_afc_extruder_as_standalone(
+            extruder_values={"toolchanger_unit": "Tools"},
+            afc_values={"standalone_auto_load_unload": False})
+        assert ext.standalone_auto_load_unload is False
+
+
+# ── _set_standalone_lane_states ─────────────────────────────────────────────────
+
+class TestSetStandaloneLaneStates:
+    def _make(self, tool_start=None):
+        ext = _make_afc_extruder()
+        ext.tool_start = tool_start
+        ext.tc_lane = MagicMock()
+        return ext
+
+    def test_none_lane_returns_without_error(self):
+        ext = self._make()
+        ext.tc_lane = None
+        ext._set_standalone_lane_states(True)  # must not raise
+
+    def test_enabled_calls_set_tool_loaded_and_set_loaded(self):
+        ext = self._make()
+        ext._set_standalone_lane_states(True)
+        ext.tc_lane.set_tool_loaded.assert_called_once_with()
+        ext.tc_lane.set_loaded.assert_called_once_with()
+
+    def test_enabled_does_not_call_unload_helpers(self):
+        ext = self._make()
+        ext._set_standalone_lane_states(True)
+        ext.tc_lane.set_tool_unloaded.assert_not_called()
+        ext.tc_lane.set_unloaded.assert_not_called()
+
+    def test_disabled_real_sensor_calls_set_tool_unloaded_only(self):
+        """Covers the `self.tool_start == "virtual"` guard's False branch."""
+        ext = self._make(tool_start="^PD3")
+        ext._set_standalone_lane_states(False)
+        ext.tc_lane.set_tool_unloaded.assert_called_once_with()
+        ext.tc_lane.set_unloaded.assert_not_called()
+
+    def test_disabled_virtual_sensor_also_calls_set_unloaded(self):
+        """Covers the `self.tool_start == "virtual"` guard's True branch."""
+        ext = self._make(tool_start="virtual")
+        ext._set_standalone_lane_states(False)
+        ext.tc_lane.set_tool_unloaded.assert_called_once_with()
+        ext.tc_lane.set_unloaded.assert_called_once_with()
+
+    def test_disabled_does_not_call_load_helpers(self):
+        ext = self._make(tool_start="virtual")
+        ext._set_standalone_lane_states(False)
+        ext.tc_lane.set_tool_loaded.assert_not_called()
+        ext.tc_lane.set_loaded.assert_not_called()
+
+
+# ── _apply_virtual_tool_start_state ──────────────────────────────────────────────
+
+class TestApplyVirtualToolStartState:
+    def _make(self, tool_start="virtual"):
+        ext = _make_afc_extruder()
+        ext.tool_start = tool_start
+        ext.fila_tool_start = MagicMock()
+        ext.tool_start_state = None
+        return ext
+
+    def test_non_virtual_sensor_is_noop(self):
+        """Covers the `self.tool_start != "virtual"` guard's True branch."""
+        ext = self._make(tool_start="^PD3")
+        ext._apply_virtual_tool_start_state(True)
+        assert ext.tool_start_state is None
+        assert ext.fila_tool_start.mock_calls == []
+
+    def test_virtual_enabled_sets_sensor_flags_true(self):
+        ext = self._make()
+        ext._apply_virtual_tool_start_state(True)
+        assert ext.fila_tool_start.runout_helper.sensor_enabled is True
+        assert ext.fila_tool_start.runout_helper.filament_present is True
+
+    def test_virtual_enabled_sets_tool_start_state_true(self):
+        ext = self._make()
+        ext._apply_virtual_tool_start_state(True)
+        assert ext.tool_start_state is True
+
+    def test_virtual_disabled_sets_sensor_flags_false(self):
+        ext = self._make()
+        ext._apply_virtual_tool_start_state(False)
+        assert ext.fila_tool_start.runout_helper.sensor_enabled is False
+        assert ext.fila_tool_start.runout_helper.filament_present is False
+
+    def test_virtual_disabled_sets_tool_start_state_false(self):
+        ext = self._make()
+        ext._apply_virtual_tool_start_state(False)
+        assert ext.tool_start_state is False
+
+    def test_non_bool_truthy_value_coerced_to_true(self):
+        """Covers `enabled = bool(enabled)` -- a truthy non-bool must behave like True."""
+        ext = self._make()
+        ext._apply_virtual_tool_start_state(1)
+        assert ext.tool_start_state is True
+        assert ext.fila_tool_start.runout_helper.sensor_enabled is True
+
+
+# ── _virtual_tool_start_toggle ────────────────────────────────────────────────
+
+class TestVirtualToolStartToggle:
+    def _make(self, prep_done=False):
+        ext = _make_afc_extruder()
+        ext.name = "extruder"
+        ext.note_tool_start_callback = MagicMock()
+        ext._apply_virtual_tool_start_state = MagicMock()
+        ext.afc.prep_done = prep_done
+        ext.afc.save_vars = MagicMock()
+        return ext
+
+    def test_calls_note_tool_start_callback(self):
+        ext = self._make()
+        ext._virtual_tool_start_toggle(True)
+        ext.note_tool_start_callback.assert_called_once_with(True)
+
+    def test_calls_apply_virtual_tool_start_state(self):
+        ext = self._make()
+        ext._virtual_tool_start_toggle(False)
+        ext._apply_virtual_tool_start_state.assert_called_once_with(False)
+
+    def test_logs_enabled_message(self):
+        """Covers the `'enabled.' if enabled else 'disabled'` ternary's True side."""
+        ext = self._make()
+        ext._virtual_tool_start_toggle(True)
+        assert ext.logger.messages == [
+            ("info", "Virtual toolhead sensor for extruder enabled.")]
+
+    def test_logs_disabled_message(self):
+        """Covers the `'enabled.' if enabled else 'disabled'` ternary's False side."""
+        ext = self._make()
+        ext._virtual_tool_start_toggle(False)
+        assert ext.logger.messages == [
+            ("info", "Virtual toolhead sensor for extruder disabled")]
+
+    def test_saves_vars_when_prep_done(self):
+        """Covers the `if self.afc.prep_done` guard's True branch."""
+        ext = self._make(prep_done=True)
+        ext._virtual_tool_start_toggle(True)
+        ext.afc.save_vars.assert_called_once_with()
+
+    def test_skips_save_vars_when_prep_not_done(self):
+        """Covers the `if self.afc.prep_done` guard's False branch."""
+        ext = self._make(prep_done=False)
+        ext._virtual_tool_start_toggle(True)
+        ext.afc.save_vars.assert_not_called()
+
+
+# ── restore_virtual_tool_start ────────────────────────────────────────────────
+
+class TestRestoreVirtualToolStart:
+    def _make(self, tool_start_state=False):
+        ext = _make_afc_extruder()
+        ext.name = "extruder"
+        ext.tool_start_state = tool_start_state
+        ext.tc_lane = MagicMock()
+        ext._apply_virtual_tool_start_state = MagicMock()
+        ext._set_standalone_lane_states = MagicMock()
+        return ext
+
+    def test_noop_when_state_already_matches(self):
+        """Covers the `enabled == self.tool_start_state` guard's True branch."""
+        ext = self._make(tool_start_state=True)
+        ext.restore_virtual_tool_start(True)
+        ext._apply_virtual_tool_start_state.assert_not_called()
+        ext._set_standalone_lane_states.assert_not_called()
+        assert ext.logger.messages == []
+
+    def test_noop_when_tc_lane_is_none(self):
+        """Covers the `self.tc_lane is None` guard's True branch."""
+        ext = self._make(tool_start_state=False)
+        ext.tc_lane = None
+        ext.restore_virtual_tool_start(True)
+        ext._apply_virtual_tool_start_state.assert_not_called()
+        assert ext.logger.messages == []
+
+    def test_applies_virtual_tool_start_state(self):
+        ext = self._make(tool_start_state=False)
+        ext.restore_virtual_tool_start(True)
+        ext._apply_virtual_tool_start_state.assert_called_once_with(True)
+
+    def test_sets_standalone_lane_states(self):
+        ext = self._make(tool_start_state=False)
+        ext.restore_virtual_tool_start(True)
+        ext._set_standalone_lane_states.assert_called_once_with(True)
+
+    def test_enabled_sets_load_state_and_prep_state_true(self):
+        ext = self._make(tool_start_state=False)
+        ext.restore_virtual_tool_start(True)
+        assert ext.tc_lane._load_state is True
+        assert ext.tc_lane.prep_state is True
+
+    def test_disabled_sets_load_state_and_prep_state_false(self):
+        ext = self._make(tool_start_state=True)
+        ext.restore_virtual_tool_start(False)
+        assert ext.tc_lane._load_state is False
+        assert ext.tc_lane.prep_state is False
+
+    def test_logs_enabled_message(self):
+        """Covers the restore-message ternary's True side."""
+        ext = self._make(tool_start_state=False)
+        ext.restore_virtual_tool_start(True)
+        assert ext.logger.messages == [
+            ("info", "Virtual toolhead sensor for extruder restored as enabled, filament loaded")]
+
+    def test_logs_disabled_message(self):
+        """Covers the restore-message ternary's False side."""
+        ext = self._make(tool_start_state=True)
+        ext.restore_virtual_tool_start(False)
+        assert ext.logger.messages == [
+            ("info", "Virtual toolhead sensor for extruder restored as disabled")]
+
+    def test_non_bool_truthy_value_coerced_to_true(self):
+        """Covers `enabled = bool(enabled)` -- a truthy non-bool must behave like True."""
+        ext = self._make(tool_start_state=False)
+        ext.restore_virtual_tool_start(1)
+        assert ext.tc_lane._load_state is True
+        ext._apply_virtual_tool_start_state.assert_called_once_with(True)

--- a/tests/test_AFC_lane.py
+++ b/tests/test_AFC_lane.py
@@ -4226,3 +4226,56 @@ class TestPrepCallback:
 
         lane_b.handle_prep_runout(20.0, False)
         lane_b.set_unloaded.assert_called_once()
+
+# ── AFCLane.move_to: virtual tool_start homing fallback ───────────────────────
+
+class TestMoveToVirtualToolStartFallback:
+    """When the extruder's tool_start is a virtual sensor there is no hardware
+    to home against, so moves targeting the tool endstop must fall back to a
+    plain distance move instead of raising "Unknown ENDSTOP 'tool'"."""
+
+    def _make_lane_with_drive_stepper(self, tool_start):
+        lane = _make_afc_lane()
+        lane.extruder_obj = MagicMock()
+        lane.extruder_obj.tool_start = tool_start
+        lane.drive_stepper = MagicMock()
+        lane.move_advanced = MagicMock()
+        lane.homing_overshoot = 10
+        lane.homing_delta = 300
+        lane.unit_obj = MagicMock()
+        lane.get_speed_accel = MagicMock(return_value=(50, 100))
+        lane.get_active_assist = MagicMock(return_value=None)
+        return lane
+
+    def test_tool_endstop_falls_back_to_plain_move_for_virtual(self):
+        lane = self._make_lane_with_drive_stepper("virtual")
+        homed, dist, warn = lane.move_to(100, SpeedMode.SHORT,
+                                         endstop=AFCHomingPoints.TOOL,
+                                         use_homing=True)
+        lane.drive_stepper.home_to.assert_not_called()
+        lane.move_advanced.assert_called_once()
+        assert homed is True
+        assert warn == AFCMoveWarning.NONE
+
+    def test_tool_start_endstop_alias_also_falls_back(self):
+        lane = self._make_lane_with_drive_stepper("virtual")
+        lane.move_to(100, SpeedMode.SHORT,
+                     endstop=AFCHomingPoints.TOOL_START, use_homing=True)
+        lane.drive_stepper.home_to.assert_not_called()
+        lane.move_advanced.assert_called_once()
+
+    def test_real_sensor_still_homes_to_tool(self):
+        lane = self._make_lane_with_drive_stepper("^PD3")
+        lane.drive_stepper.home_to.return_value = (True, 100, None)
+        lane.move_to(100, SpeedMode.SHORT, endstop=AFCHomingPoints.TOOL,
+                     use_homing=True)
+        lane.drive_stepper.home_to.assert_called_once()
+        lane.move_advanced.assert_not_called()
+
+    def test_other_endstops_unaffected_by_virtual(self):
+        lane = self._make_lane_with_drive_stepper("virtual")
+        lane.drive_stepper.home_to.return_value = (True, 100, None)
+        lane.move_to(100, SpeedMode.SHORT, endstop=AFCHomingPoints.HUB,
+                     use_homing=True)
+        lane.drive_stepper.home_to.assert_called_once()
+        lane.move_advanced.assert_not_called()

--- a/tests/test_AFC_lane.py
+++ b/tests/test_AFC_lane.py
@@ -228,6 +228,7 @@ def _make_afc_lane(fullname="AFC_stepper lane1"):
     lane._sent_lane_data_keys = []
     lane.gcode = MagicMock()
     lane.need_purge = False
+    lane._afc_prep_done = False
     return lane
 
 
@@ -4226,56 +4227,3 @@ class TestPrepCallback:
 
         lane_b.handle_prep_runout(20.0, False)
         lane_b.set_unloaded.assert_called_once()
-
-# ── AFCLane.move_to: virtual tool_start homing fallback ───────────────────────
-
-class TestMoveToVirtualToolStartFallback:
-    """When the extruder's tool_start is a virtual sensor there is no hardware
-    to home against, so moves targeting the tool endstop must fall back to a
-    plain distance move instead of raising "Unknown ENDSTOP 'tool'"."""
-
-    def _make_lane_with_drive_stepper(self, tool_start):
-        lane = _make_afc_lane()
-        lane.extruder_obj = MagicMock()
-        lane.extruder_obj.tool_start = tool_start
-        lane.drive_stepper = MagicMock()
-        lane.move_advanced = MagicMock()
-        lane.homing_overshoot = 10
-        lane.homing_delta = 300
-        lane.unit_obj = MagicMock()
-        lane.get_speed_accel = MagicMock(return_value=(50, 100))
-        lane.get_active_assist = MagicMock(return_value=None)
-        return lane
-
-    def test_tool_endstop_falls_back_to_plain_move_for_virtual(self):
-        lane = self._make_lane_with_drive_stepper("virtual")
-        homed, dist, warn = lane.move_to(100, SpeedMode.SHORT,
-                                         endstop=AFCHomingPoints.TOOL,
-                                         use_homing=True)
-        lane.drive_stepper.home_to.assert_not_called()
-        lane.move_advanced.assert_called_once()
-        assert homed is True
-        assert warn == AFCMoveWarning.NONE
-
-    def test_tool_start_endstop_alias_also_falls_back(self):
-        lane = self._make_lane_with_drive_stepper("virtual")
-        lane.move_to(100, SpeedMode.SHORT,
-                     endstop=AFCHomingPoints.TOOL_START, use_homing=True)
-        lane.drive_stepper.home_to.assert_not_called()
-        lane.move_advanced.assert_called_once()
-
-    def test_real_sensor_still_homes_to_tool(self):
-        lane = self._make_lane_with_drive_stepper("^PD3")
-        lane.drive_stepper.home_to.return_value = (True, 100, None)
-        lane.move_to(100, SpeedMode.SHORT, endstop=AFCHomingPoints.TOOL,
-                     use_homing=True)
-        lane.drive_stepper.home_to.assert_called_once()
-        lane.move_advanced.assert_not_called()
-
-    def test_other_endstops_unaffected_by_virtual(self):
-        lane = self._make_lane_with_drive_stepper("virtual")
-        lane.drive_stepper.home_to.return_value = (True, 100, None)
-        lane.move_to(100, SpeedMode.SHORT, endstop=AFCHomingPoints.HUB,
-                     use_homing=True)
-        lane.drive_stepper.home_to.assert_called_once()
-        lane.move_advanced.assert_not_called()

--- a/tests/test_AFC_stepper.py
+++ b/tests/test_AFC_stepper.py
@@ -810,6 +810,68 @@ class TestInitEndstopsFpsPfsBuffer:
         assert tool_start_calls[0].args[1] == "PC6"
 
 
+class TestInitEndstopsVirtualToolStart:
+    """Exercises the `tool_start_pin.lower() == "virtual"` branch inside
+    _init_endstops(): a virtual tool_start sensor has no hardware pin, so no
+    tool_start endstop should be registered for it."""
+
+    def _make_endstop_stepper(self, section_values, name="lane1"):
+        return TestInitEndstopsFpsPfsBuffer()._make_endstop_stepper(section_values, name)
+
+    def test_virtual_tool_start_skips_endstop_registration(self):
+        s = self._make_endstop_stepper({
+            ("AFC_extruder", "extruder", "pin_tool_start"): "virtual",
+        })
+
+        s._init_endstops()  # should not raise
+
+        tool_start_calls = [c for c in s._add_endstop.call_args_list
+                            if c.args[0] == "tool_start"]
+        assert tool_start_calls == []
+
+    def test_virtual_tool_start_case_insensitive(self):
+        """Covers `.lower()` -- config value casing shouldn't matter."""
+        s = self._make_endstop_stepper({
+            ("AFC_extruder", "extruder", "pin_tool_start"): "VIRTUAL",
+        })
+
+        s._init_endstops()
+
+        tool_start_calls = [c for c in s._add_endstop.call_args_list
+                            if c.args[0] == "tool_start"]
+        assert tool_start_calls == []
+
+    def test_none_tool_start_pin_does_not_match_virtual_branch(self):
+        """Covers the `tool_start_pin is not None` guard's False branch: a
+        missing pin_tool_start must not raise from the virtual-check itself
+        (AttributeError on NoneType.lower) and instead fall through to the
+        `elif tool_start_pin != 'buffer'` branch."""
+        s = self._make_endstop_stepper({
+            ("AFC_extruder", "extruder", "pin_tool_start"): None,
+        })
+
+        s._init_endstops()  # should not raise on None.lower()
+
+        tool_start_calls = [c for c in s._add_endstop.call_args_list
+                            if c.args[0] == "tool_start"]
+        assert len(tool_start_calls) == 1
+        assert tool_start_calls[0].args[1] is None
+
+    def test_real_pin_still_registers_tool_start_endstop(self):
+        """Regression check: a normal hardware pin is unaffected by the
+        virtual-sensor addition."""
+        s = self._make_endstop_stepper({
+            ("AFC_extruder", "extruder", "pin_tool_start"): "^PD3",
+        })
+
+        s._init_endstops()
+
+        tool_start_calls = [c for c in s._add_endstop.call_args_list
+                            if c.args[0] == "tool_start"]
+        assert len(tool_start_calls) == 1
+        assert tool_start_calls[0].args[1] == "^PD3"
+
+
 class TestAddEndstopMcuEndstopParam:
     """Exercises _add_endstop's mcu_endstop parameter, which lets a
     pre-built MCU endstop (e.g. an FPS software endstop) be registered

--- a/tests/test_AFC_utils.py
+++ b/tests/test_AFC_utils.py
@@ -1375,3 +1375,26 @@ class TestVirtualFilamentSensor:
         gcmd = MockGCodeCommand(params={"ENABLE": 0})
         sensor.cmd_SET_FILAMENT_SENSOR(gcmd)
         assert sensor.runout_helper.sensor_enabled is False
+
+    def test_cmd_set_filament_sensor_invokes_enable_callback(self):
+        printer = self._make_printer_with_add_object()
+        enable_cb = MagicMock()
+        sensor = VirtualFilamentSensor(printer, "FPS1_expanded", logger=MagicMock(),
+                                       enable_cb=enable_cb)
+        gcmd = MockGCodeCommand(params={"ENABLE": 1})
+        sensor.cmd_SET_FILAMENT_SENSOR(gcmd)
+        assert sensor.runout_helper.sensor_enabled is True
+        enable_cb.assert_called_once_with(True)
+
+        gcmd = MockGCodeCommand(params={"ENABLE": 0})
+        sensor.cmd_SET_FILAMENT_SENSOR(gcmd)
+        assert sensor.runout_helper.sensor_enabled is False
+        enable_cb.assert_called_with(False)
+
+    def test_cmd_set_filament_sensor_without_callback(self):
+        """Buffers and other users pass no enable_cb -- toggling must still work."""
+        printer = self._make_printer_with_add_object()
+        sensor = VirtualFilamentSensor(printer, "FPS1_expanded", logger=MagicMock())
+        gcmd = MockGCodeCommand(params={"ENABLE": 1})
+        sensor.cmd_SET_FILAMENT_SENSOR(gcmd)
+        assert sensor.runout_helper.sensor_enabled is True


### PR DESCRIPTION
Closes #810.

## Major Changes in this PR

Adds a new `pin_tool_start: virtual` option for `[AFC_extruder]` sections. When set, AFC creates a software-only toolhead sensor for the extruder by reusing the existing `VirtualFilamentSensor` helper (the same building block the virtual bypass / FPS sensors use), instead of registering a hardware pin:

- the sensor reports filament present from startup (`tool_start_state = True`),
- no buttons/pins are registered (state can not flap or trigger false runouts),
- the sensor still shows up as `filament_switch_sensor <extruder>_tool_start` in the GUI.

This covers toolchanger setups that run standalone lanes on a toolhead without a physical toolhead sensor: the standalone lane now reports as loaded, so tool changes no longer abort with `TOOL_LOAD: Please load lane before continuing` and no manual `SET_LANE_LOADED` is needed after PREP.

## Notes to Code Reviewers

- The change is one `elif` branch in `AFCExtruder.__init__` plus the import; the `buffer` special case and hardware-pin path are untouched.
- `VirtualFilamentSensor` is instantiated with `enable_runout` mirroring the hardware path; since nothing can ever drive its state to filament-absent, the runout callback stays dormant.
- Follows the same pattern as the virtual bypass sensor, as suggested in #810.

## How the changes in this PR are tested

- New unit tests in `tests/test_AFC_extruder.py` (`TestVirtualToolStart`): sensor state assumed loaded at init, no debounce button registered, and `handle_ready()` marks the standalone tc_lane as loaded.
- Full `tests/` suite passes locally (excluding the pre-existing `tests/install` characterization failures that also fail on a clean tree for me).
- Verified on real hardware: Tridex-style IDEX toolchanger, left toolhead as a standalone lane (`map: T0`) with no physical sensor. With `pin_tool_start: virtual`: klippy starts clean, PREP reports `extruder tool cmd: T0 LOADED in ToolHead`, `M104/M109 T0` resolves through the standalone lane, and T-command tool changes complete without the `Please load lane` abort.

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [x] Documentation updated in AT-Documentation repository
- [x] Sent notification to pr-review channel requesting review
- [x] If this PR address a GitHub issue, the issue number is referenced in the PR description

Documentation: updated in ArmoredTurtle/AT-Documentation#188 (pin_tool_start reference in AFC_Hardware.cfg). Notification to the pr-review channel: will send once reviewers confirm the preferred channel.

---

*Note: parts of this change were written with the assistance of an AI model (GLM-5.3 by Z.ai) and were reviewed, unit-tested and verified by me on real hardware before submitting.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for virtual toolhead filament sensing.
  * Virtual toolheads start unloaded and disabled, with state saved and restored during preparation.
  * Filament presence can be toggled through the GUI or `SET_FILAMENT_SENSOR`.
  * Standalone load and unload operations can be disabled.
  * Sensor state stays synchronized with filament operations.
  * Virtual toolheads no longer require hardware homing.

* **Bug Fixes**
  * Improved lane state tracking, runout handling, metadata updates, and asynchronous Moonraker operations.
  * Ooze-prevention temperature checks are disabled by default for lanes sharing an extruder.

* **Documentation**
  * Updated the unreleased changelog with virtual sensor behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

