### PR TITLE
(hotfix): Bringing in change from main that fixes klipper changing absolute_extrude in PR 7349

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-08-23]
+### Fixed
+- AFC no longer crashes with `AttributeError: 'GCodeMove' object has no attribute 'absolute_extrude'` during tool changes on current Klipper master builds. Klipper renamed the `absolute_extrude` attribute to `allow_absolute_extrude` (v0.13.0-741 and newer); AFC now reads and restores whichever attribute name the host provides, so it keeps working on older and newer Klipper alike.
+
 ## [2026-08-22]
 ### Added
 - Lane and extruder status LEDs can now overlay a `SET_LED_EFFECT` animation on top of the usual

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -37,7 +37,8 @@ except: raise error(ERROR_STR.format(import_lib="AFC_logger", trace=traceback.fo
 try: from extras.AFC_logger import AFC_logger
 except: raise error(ERROR_STR.format(import_lib="AFC_logger", trace=traceback.format_exc()))
 
-try: from extras.AFC_functions import afcDeltaTime, round_floats, get_gcode_absolute_extrude, set_gcode_absolute_extrude
+try:
+    from extras.AFC_functions import afcDeltaTime, round_floats, get_gcode_absolute_extrude, set_gcode_absolute_extrude
 except: raise error(ERROR_STR.format(import_lib="AFC_functions", trace=traceback.format_exc()))
 
 try: from extras.AFC_utils import add_filament_switch, AFC_moonraker, AFC_PrintFileMetaData

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -37,7 +37,7 @@ except: raise error(ERROR_STR.format(import_lib="AFC_logger", trace=traceback.fo
 try: from extras.AFC_logger import AFC_logger
 except: raise error(ERROR_STR.format(import_lib="AFC_logger", trace=traceback.format_exc()))
 
-try: from extras.AFC_functions import afcDeltaTime, round_floats
+try: from extras.AFC_functions import afcDeltaTime, round_floats, get_gcode_absolute_extrude, set_gcode_absolute_extrude
 except: raise error(ERROR_STR.format(import_lib="AFC_functions", trace=traceback.format_exc()))
 
 try: from extras.AFC_utils import add_filament_switch, AFC_moonraker, AFC_PrintFileMetaData
@@ -1163,7 +1163,7 @@ class afc:
                 self.speed                  = self.gcode_move.speed
                 self.speed_factor           = self.gcode_move.speed_factor
                 self.absolute_coord         = self.gcode_move.absolute_coord
-                self.absolute_extrude       = self.gcode_move.absolute_extrude
+                self.absolute_extrude       = get_gcode_absolute_extrude(self.gcode_move)
                 self.extrude_factor         = self.gcode_move.extrude_factor
                 # Only rounded for the log message below, stored position values keep full precision
                 msg = f"Saving position {round_floats(self.last_toolhead_position)}"
@@ -1236,7 +1236,7 @@ class afc:
 
         # Restore absolute coords
         self.gcode_move.absolute_coord      = self.absolute_coord
-        self.gcode_move.absolute_extrude    = self.absolute_extrude
+        set_gcode_absolute_extrude(self.gcode_move, self.absolute_extrude)
         self.gcode_move.extrude_factor      = self.extrude_factor
         self.gcode_move.speed               = self.speed
         self.gcode_move.speed_factor        = self.speed_factor

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -18,6 +18,7 @@ from typing import Dict, TYPE_CHECKING, Union, Any, Optional, Tuple, List
 if TYPE_CHECKING:
     from configfile import ConfigWrapper
     from gcode import GCodeDispatch, GCodeCommand
+    from extras.gcode_move import GCodeMove
     from extras.AFC_lane import AFCLane
     from extras.AFC_extruder import AFCExtruder
     from extras.AFC_functions import afcFunction
@@ -38,7 +39,11 @@ try: from extras.AFC_logger import AFC_logger
 except: raise error(ERROR_STR.format(import_lib="AFC_logger", trace=traceback.format_exc()))
 
 try:
-    from extras.AFC_functions import afcDeltaTime, round_floats, get_gcode_absolute_extrude, set_gcode_absolute_extrude
+    from extras.AFC_functions import (
+        afcDeltaTime, round_floats,
+        get_gcode_absolute_extrude,
+        set_gcode_absolute_extrude
+    )
 except: raise error(ERROR_STR.format(import_lib="AFC_functions", trace=traceback.format_exc()))
 
 try: from extras.AFC_utils import add_filament_switch, AFC_moonraker, AFC_PrintFileMetaData
@@ -433,7 +438,7 @@ class afc:
         """
         self.toolhead   = self.printer.lookup_object('toolhead')
         self.idle       = self.printer.lookup_object('idle_timeout')
-        self.gcode_move = self.printer.lookup_object('gcode_move')
+        self.gcode_move: GCodeMove = self.printer.lookup_object('gcode_move')
 
         # Looking up to see if manual_home has probe_pos, this is to make AFC work with klipper
         # starting with new homing update git hash(57c2e0c960f8e25f56a66ba3a1e90e124f207001)

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -64,6 +64,51 @@ def round_floats(value: Any, digits: int = 6) -> Any:
     return value
 
 
+def get_gcode_absolute_extrude(gcode_move: Any, eventtime: Optional[float] = None) -> Any:
+    """
+    Read Klipper GCodeMove absolute-extrude state.
+
+    Klipper PR 7349 renamed the internal attribute from absolute_extrude to
+    allow_absolute_extrude. The get_status() key remains 'absolute_extrude'.
+    Prefer that status key; fall back to either attribute name.
+
+    :param gcode_move: Klipper gcode_move object
+    :param eventtime: Optional event time forwarded to get_status()
+    :return Any: Current absolute-extrude flag (status key name unchanged)
+    """
+    get_status = getattr(gcode_move, "get_status", None)
+    if callable(get_status):
+        try:
+            status = get_status() if eventtime is None else get_status(eventtime)
+        except TypeError:
+            status = get_status(eventtime)
+        if isinstance(status, dict) and "absolute_extrude" in status:
+            return status["absolute_extrude"]
+    if hasattr(gcode_move, "allow_absolute_extrude"):
+        return gcode_move.allow_absolute_extrude
+    return getattr(gcode_move, "absolute_extrude", True)
+
+
+def set_gcode_absolute_extrude(gcode_move: Any, value: bool) -> None:
+    """
+    Write Klipper GCodeMove absolute-extrude state.
+
+    Sets allow_absolute_extrude on post-PR-7349 Klipper and absolute_extrude
+    on older Klipper (hasattr / getattr compatibility).
+
+    :param gcode_move: Klipper gcode_move object
+    :param value: Absolute-extrude flag to restore
+    """
+    has_new = hasattr(gcode_move, "allow_absolute_extrude")
+    has_old = hasattr(gcode_move, "absolute_extrude")
+    # New name present, or old name missing: write the post-7349 attribute.
+    if has_new or not has_old:
+        gcode_move.allow_absolute_extrude = value
+    # Old name present, or new name missing: write the legacy attribute.
+    if has_old or not has_new:
+        gcode_move.absolute_extrude = value
+
+
 def load_config(config):
     return afcFunction(config)
 
@@ -667,7 +712,7 @@ class afcFunction:
         msg += f" speed_factor: {round_floats(self.afc.gcode_move.speed_factor)}"
         msg += f" extrude_factor: {round_floats(self.afc.gcode_move.extrude_factor)}"
         msg += f" absolute_coord: {self.afc.gcode_move.absolute_coord}"
-        msg += f" absolute_extrude: {self.afc.gcode_move.absolute_extrude}\n"
+        msg += f" absolute_extrude: {get_gcode_absolute_extrude(self.afc.gcode_move)}\n"
         self.logger.debug(msg, only_debug=True)
 
     def check_absolute_mode( self, func_name:str="" ):
@@ -683,9 +728,9 @@ class afcFunction:
         if not self.afc.gcode_move.absolute_coord:
             self.logger.debug("Printer coords not in absolute mode, setting to absolute mode")
             self.afc.gcode_move.absolute_coord = True
-        if not self.afc.gcode_move.absolute_extrude:
+        if not get_gcode_absolute_extrude(self.afc.gcode_move):
             self.logger.debug("Printer extruder not in absolute mode, setting to absolute mode")
-            self.afc.gcode_move.absolute_extrude = True
+            set_gcode_absolute_extrude(self.afc.gcode_move, True)
 
     def get_extruder_pos(self, eventtime=None, past_extruder_position=None, extruder=None):
         """

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -382,7 +382,7 @@ class afcFunction:
         else:
             return True
 
-    def is_homed(self, for_move=False):
+    def is_homed(self, for_move: bool=False) -> bool:
         """
         Helper function to determine if printer is currently homed
 

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
     from extras.AFC_stepper import AFCExtruderStepper
     from extras.AFC_hub import afc_hub
     from gcode import GCodeCommand
+    from extras.gcode_move import GCodeMove
 
 try: from extras.AFC_utils import ERROR_STR
 except: raise error("Error when trying to import AFC_utils.ERROR_STR\n{trace}".format(trace=traceback.format_exc()))
@@ -64,32 +65,22 @@ def round_floats(value: Any, digits: int = 6) -> Any:
     return value
 
 
-def get_gcode_absolute_extrude(gcode_move: Any, eventtime: Optional[float] = None) -> Any:
+def get_gcode_absolute_extrude(gcode_move: GCodeMove) -> bool:
     """
     Read Klipper GCodeMove absolute-extrude state.
 
     Klipper PR 7349 renamed the internal attribute from absolute_extrude to
-    allow_absolute_extrude. The get_status() key remains 'absolute_extrude'.
-    Prefer that status key; fall back to either attribute name.
+    allow_absolute_extrude.
 
     :param gcode_move: Klipper gcode_move object
-    :param eventtime: Optional event time forwarded to get_status()
-    :return Any: Current absolute-extrude flag (status key name unchanged)
+    :return bool: Current absolute-extrude flag
     """
-    get_status = getattr(gcode_move, "get_status", None)
-    if callable(get_status):
-        try:
-            status = get_status() if eventtime is None else get_status(eventtime)
-        except TypeError:
-            status = get_status(eventtime)
-        if isinstance(status, dict) and "absolute_extrude" in status:
-            return status["absolute_extrude"]
     if hasattr(gcode_move, "allow_absolute_extrude"):
         return gcode_move.allow_absolute_extrude
     return getattr(gcode_move, "absolute_extrude", True)
 
 
-def set_gcode_absolute_extrude(gcode_move: Any, value: bool) -> None:
+def set_gcode_absolute_extrude(gcode_move: GCodeMove, value: bool) -> None:
     """
     Write Klipper GCodeMove absolute-extrude state.
 
@@ -107,7 +98,6 @@ def set_gcode_absolute_extrude(gcode_move: Any, value: bool) -> None:
     # Old name present, or new name missing: write the legacy attribute.
     if has_old or not has_new:
         gcode_move.absolute_extrude = value
-
 
 def load_config(config):
     return afcFunction(config)

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -69,7 +69,7 @@ def get_gcode_absolute_extrude(gcode_move: GCodeMove) -> bool:
     """
     Read Klipper GCodeMove absolute-extrude state.
 
-    Klipper PR 7349 renamed the internal attribute from absolute_extrude to
+    Klipper PR 7349(v0.13.0-741) renamed the internal attribute from absolute_extrude to
     allow_absolute_extrude.
 
     :param gcode_move: Klipper gcode_move object

--- a/tests/test_AFC.py
+++ b/tests/test_AFC.py
@@ -2831,6 +2831,8 @@ def _make_afc_for_save_pos():
     obj.gcode_move.speed_factor = 0.016666666666666666
     obj.gcode_move.absolute_coord = True
     obj.gcode_move.absolute_extrude = False
+    obj.gcode_move.allow_absolute_extrude = False
+    obj.gcode_move.get_status.return_value = {"absolute_extrude": False}
     obj.gcode_move.extrude_factor = 1.0
     obj.toolhead.get_position.return_value = [
         165.174093123, 256.300678987, 3.0715305953986847, 2882.80021999998,
@@ -3080,6 +3082,7 @@ class TestRestorePos:
         assert obj.gcode_move.homing_position == [0.0, 0.0, 0.0, 0.0]
         assert obj.gcode_move.absolute_coord is True
         assert obj.gcode_move.absolute_extrude is False
+        assert obj.gcode_move.allow_absolute_extrude is False
         assert obj.gcode_move.extrude_factor == 1.0
         assert obj.gcode_move.speed == 350.0
         assert obj.gcode_move.speed_factor == 0.016666666666666666

--- a/tests/test_AFC_functions.py
+++ b/tests/test_AFC_functions.py
@@ -138,6 +138,20 @@ class _NewKlipperGCodeMove:
         return {"absolute_extrude": self.allow_absolute_extrude}
 
 
+class _OldKlipperGCodeMoveAttrOnly:
+    """Legacy Klipper mock with absolute_extrude and no get_status()."""
+
+    def __init__(self, value):
+        self.absolute_extrude = value
+
+
+class _NewKlipperGCodeMoveAttrOnly:
+    """Post-PR-7349 Klipper mock with allow_absolute_extrude and no get_status()."""
+
+    def __init__(self, value):
+        self.allow_absolute_extrude = value
+
+
 class TestGcodeAbsoluteExtrudeCompat:
     def test_reads_status_key_on_new_klipper(self):
         move = _NewKlipperGCodeMove(False)
@@ -145,6 +159,16 @@ class TestGcodeAbsoluteExtrudeCompat:
 
     def test_reads_status_key_on_old_klipper(self):
         move = _OldKlipperGCodeMove(False)
+        assert get_gcode_absolute_extrude(move) is False
+
+    def test_reads_attr_on_old_klipper_without_get_status(self):
+        move = _OldKlipperGCodeMoveAttrOnly(False)
+        assert not hasattr(move, "get_status")
+        assert get_gcode_absolute_extrude(move) is False
+
+    def test_reads_attr_on_new_klipper_without_get_status(self):
+        move = _NewKlipperGCodeMoveAttrOnly(False)
+        assert not hasattr(move, "get_status")
         assert get_gcode_absolute_extrude(move) is False
 
     def test_writes_allow_absolute_extrude_on_new_klipper(self):

--- a/tests/test_AFC_functions.py
+++ b/tests/test_AFC_functions.py
@@ -123,19 +123,21 @@ class TestLogToolheadPos:
 # ── Klipper PR 7349 absolute_extrude compat ───────────────────────────────────
 
 class _OldKlipperGCodeMove:
-    def __init__(self, value):
+    def __init__(self, value, status_value=None):
         self.absolute_extrude = value
+        self._status_value = value if status_value is None else status_value
 
     def get_status(self, eventtime=None):
-        return {"absolute_extrude": self.absolute_extrude}
+        return {"absolute_extrude": self._status_value}
 
 
 class _NewKlipperGCodeMove:
-    def __init__(self, value):
+    def __init__(self, value, status_value=None):
         self.allow_absolute_extrude = value
+        self._status_value = value if status_value is None else status_value
 
     def get_status(self, eventtime=None):
-        return {"absolute_extrude": self.allow_absolute_extrude}
+        return {"absolute_extrude": self._status_value}
 
 
 class _OldKlipperGCodeMoveAttrOnly:
@@ -153,14 +155,6 @@ class _NewKlipperGCodeMoveAttrOnly:
 
 
 class TestGcodeAbsoluteExtrudeCompat:
-    def test_reads_status_key_on_new_klipper(self):
-        move = _NewKlipperGCodeMove(False)
-        assert get_gcode_absolute_extrude(move) is False
-
-    def test_reads_status_key_on_old_klipper(self):
-        move = _OldKlipperGCodeMove(False)
-        assert get_gcode_absolute_extrude(move) is False
-
     def test_reads_attr_on_old_klipper_without_get_status(self):
         move = _OldKlipperGCodeMoveAttrOnly(False)
         assert not hasattr(move, "get_status")
@@ -170,6 +164,23 @@ class TestGcodeAbsoluteExtrudeCompat:
         move = _NewKlipperGCodeMoveAttrOnly(False)
         assert not hasattr(move, "get_status")
         assert get_gcode_absolute_extrude(move) is False
+
+    def test_ignores_get_status_on_new_klipper(self):
+        """get_gcode_absolute_extrude no longer consults get_status() at all
+        (Klipper PR 7349 compat fix) -- a stale/conflicting status dict must
+        not influence the result, only the allow_absolute_extrude attr does."""
+        move = _NewKlipperGCodeMove(False, status_value=True)
+        assert get_gcode_absolute_extrude(move) is False
+
+    def test_ignores_get_status_on_old_klipper(self):
+        move = _OldKlipperGCodeMove(False, status_value=True)
+        assert get_gcode_absolute_extrude(move) is False
+
+    def test_defaults_to_true_when_neither_attribute_present(self):
+        """Covers the final getattr(..., True) fallback when the gcode_move
+        object exposes neither allow_absolute_extrude nor absolute_extrude."""
+        move = object()
+        assert get_gcode_absolute_extrude(move) is True
 
     def test_writes_allow_absolute_extrude_on_new_klipper(self):
         move = _NewKlipperGCodeMove(False)

--- a/tests/test_AFC_functions.py
+++ b/tests/test_AFC_functions.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch, call
 import pytest
 
-from extras.AFC_functions import afcFunction, afcDeltaTime, round_floats
+from extras.AFC_functions import afcFunction, afcDeltaTime, round_floats, get_gcode_absolute_extrude, set_gcode_absolute_extrude
 from extras.AFC_respond import AFCprompt
 
 from tests.test_AFC import _make_afc
@@ -86,6 +86,8 @@ class TestLogToolheadPos:
         func.afc.gcode_move.extrude_factor = 1.0
         func.afc.gcode_move.absolute_coord = True
         func.afc.gcode_move.absolute_extrude = False
+        func.afc.gcode_move.allow_absolute_extrude = False
+        func.afc.gcode_move.get_status.return_value = {"absolute_extrude": False}
 
     def test_logs_expected_message_with_move_pre(self):
         func = _make_func()
@@ -116,6 +118,59 @@ class TestLogToolheadPos:
             "absolute_coord: True absolute_extrude: False\n"
         )
         assert func.logger.messages == [("debug", expected)]
+
+
+# ── Klipper PR 7349 absolute_extrude compat ───────────────────────────────────
+
+class _OldKlipperGCodeMove:
+    def __init__(self, value):
+        self.absolute_extrude = value
+
+    def get_status(self, eventtime=None):
+        return {"absolute_extrude": self.absolute_extrude}
+
+
+class _NewKlipperGCodeMove:
+    def __init__(self, value):
+        self.allow_absolute_extrude = value
+
+    def get_status(self, eventtime=None):
+        return {"absolute_extrude": self.allow_absolute_extrude}
+
+
+class TestGcodeAbsoluteExtrudeCompat:
+    def test_reads_status_key_on_new_klipper(self):
+        move = _NewKlipperGCodeMove(False)
+        assert get_gcode_absolute_extrude(move) is False
+
+    def test_reads_status_key_on_old_klipper(self):
+        move = _OldKlipperGCodeMove(False)
+        assert get_gcode_absolute_extrude(move) is False
+
+    def test_writes_allow_absolute_extrude_on_new_klipper(self):
+        move = _NewKlipperGCodeMove(False)
+        set_gcode_absolute_extrude(move, True)
+        assert move.allow_absolute_extrude is True
+        assert not hasattr(move, "absolute_extrude")
+
+    def test_writes_absolute_extrude_on_old_klipper(self):
+        move = _OldKlipperGCodeMove(False)
+        set_gcode_absolute_extrude(move, True)
+        assert move.absolute_extrude is True
+        assert not hasattr(move, "allow_absolute_extrude")
+
+    def test_check_absolute_mode_sets_new_klipper_attr(self):
+        func = _make_func()
+        func.afc.gcode_move = _NewKlipperGCodeMove(False)
+        func.afc.gcode_move.absolute_coord = True
+        func.afc.gcode_move.base_position = [0, 0, 0, 0]
+        func.afc.gcode_move.last_position = [0, 0, 0, 0]
+        func.afc.gcode_move.speed = 1.0
+        func.afc.gcode_move.speed_factor = 1.0
+        func.afc.gcode_move.extrude_factor = 1.0
+        func.afc.toolhead.get_position.return_value = [0, 0, 0, 0]
+        func.check_absolute_mode("TEST")
+        assert func.afc.gcode_move.allow_absolute_extrude is True
 
 
 # ── HexConvert ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Major Changes in this PR
Bringing in changes from main branch to fix issue with klipper changing absolute_extruder in PR 7349, v0.13.0-741 and newer

## Notes to Code Reviewers

## How the changes in this PR are tested
Tested on klipper before/after the breaking PR and verified it still worked on kalico

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [ ] I have performed a self-review of my code
- [ ] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [ ] Sent notification to pr-review channel requesting review
- [ ] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed crashes during tool changes on newer Klipper versions.
  * Improved compatibility with legacy and current absolute-extrusion settings.
  * Preserved extrusion-mode state when saving and restoring toolhead positions.

* **Tests**
  * Added coverage for supported Klipper attribute formats, fallback behavior, and state restoration.

* **Documentation**
  * Added a changelog entry describing the compatibility fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->