### PR TITLE
(feat): Moving writing afc.vars file and moonraker calls to separate threads so they can be async

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2026-08-23]
 ### Added:
-- Added thread for writing vars to file so that slow disks don't have a change to block on writes which could cause timer too codes errors.
-- Added thread for communicating with moonraker, converted most of the call to moonraker to be asyncronous so that AFC does not block klippers main reactor thread. Left some calls during start up sychronous and the calls for TD-1 when calibrating.
+- Added thread for writing vars to file so that slow disks don't have a chance to block on writes which could cause timer too close errors.
+- Added thread for communicating with moonraker, converted most of the call to moonraker to be asynchronous so that AFC does not block klippers main reactor thread. Left some calls during start up sychronous and the calls for TD-1 when calibrating.
 
 ### Fixed
 - AFC no longer crashes with `AttributeError: 'GCodeMove' object has no attribute 'absolute_extrude'` during tool changes on current Klipper master builds. Klipper renamed the `absolute_extrude` attribute to `allow_absolute_extrude` (v0.13.0-741 and newer); AFC now reads and restores whichever attribute name the host provides, so it keeps working on older and newer Klipper alike.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [2026-08-23]
+### Added:
+- Added thread for writing vars to file so that slow disks don't have a change to block on writes which could cause timer too codes errors.
+- Added thread for communicating with moonraker, converted most of the call to moonraker to be asyncronous so that AFC does not block klippers main reactor thread. Left some calls during start up sychronous and the calls for TD-1 when calibrating.
+
 ### Fixed
 - AFC no longer crashes with `AttributeError: 'GCodeMove' object has no attribute 'absolute_extrude'` during tool changes on current Klipper master builds. Klipper renamed the `absolute_extrude` attribute to `allow_absolute_extrude` (v0.13.0-741 and newer); AFC now reads and restores whichever attribute name the host provides, so it keeps working on older and newer Klipper alike.
 

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -8,6 +8,8 @@ import json
 import re
 import traceback
 import inspect
+import queue
+import threading
 from enum import Enum
 from functools import cached_property
 from configfile import error
@@ -161,6 +163,13 @@ class afc:
         self.unit_order_list        = config.get('unit_order_list','')
         self.VarFile                = config.get('VarFile','../printer_data/config/AFC/AFC.var')# Path to the variables file for AFC configuration.
         self.cfgloc                 = self._remove_after_last(self.VarFile,"/")
+
+        # save_vars() only builds the state dict on the reactor thread; the actual file
+        # write happens on this background thread so a slow disk can't stall Klipper.
+        # A single worker (rather than a thread per call) keeps writes ordered.
+        self._var_write_queue: queue.Queue = queue.Queue()
+        self._var_write_thread = threading.Thread(target=self._var_write_worker, daemon=True)
+        self._var_write_thread.start()
         self.default_material_temps = config.getlists("default_material_temps",
                                                       ("default: 235", "PLA:210", "PETG:235", "ABS:235", "ASA:235"))# Default temperature to set extruder when loading/unloading lanes. Material needs to be either manually set or uses material from spoolman if extruder temp is not set in spoolman.
         self.default_material_temps = list(self.default_material_temps) if self.default_material_temps is not None else None
@@ -1294,12 +1303,47 @@ class afc:
             str["system"]["extruders"][cur_extruder.name]={}
             str["system"]["extruders"][cur_extruder.name]['lane_loaded'] = cur_extruder.lane_loaded
 
+        # Handing off to the background writer thread so a slow disk doesn't
+        # block the reactor; queue.put_nowait never blocks the caller here
+        self._var_write_queue.put_nowait(str)
+
+    def _var_write_worker(self) -> None:
+        """
+        Background thread loop that pulls queued save_vars() values and
+        writes them to VarFile.unit file in the order they were queued. Runs for
+        the life of the process (daemon thread) so it needs no explicit shutdown.
+        """
+        while True:
+            data = self._var_write_queue.get()
+            self._write_vars_snapshot(data)
+
+    def _write_vars_snapshot(self, data: dict) -> None:
+        """
+        Writes a single save_vars() values to VarFile.unit. Called from the
+        background writer thread, so a slow disk only blocks that thread and
+        not the reactor.
+
+        :param data: Dictionary of lane/unit/system state to write to VarFile.unit
+        """
         try:
-            with open(self.VarFile+ '.unit', 'w') as f:
-                f.write(json.dumps(str, indent=4))
+            with open(self.VarFile + '.unit', 'w') as f:
+                f.write(json.dumps(data, indent=4))
         except Exception as e:
-            self.logger.error("Error happened when trying to save variables, check AFC.log for error")
-            self.logger.debug(f"Error:{e}\n{traceback.format_exc()}", only_debug=True)
+            err = f"Error:{e}\n{traceback.format_exc()}"
+            # Push back onto the reactor thread before logging: AFC_logger
+            # touches gcode/webhooks state that isn't safe to call from here
+            self.reactor.register_async_callback(
+                lambda et, err=err: self._log_save_vars_error(err))
+
+    def _log_save_vars_error(self, err: str) -> None:
+        """
+        Logs a save_vars file-write failure. Called back on the reactor thread
+        via register_async_callback since the write happens on a background thread.
+
+        :param err: Formatted error/traceback string to log
+        """
+        self.logger.error("Error happened when trying to save variables, check AFC.log for error")
+        self.logger.debug(err, only_debug=True)
 
     # HUB COMMANDS
     cmd_HUB_LOAD_help = "Load lane into hub"

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -8,10 +8,12 @@ import json
 import re
 import traceback
 import inspect
-import queue
 import threading
+import chelper
+
 from enum import Enum
 from functools import cached_property
+from queue import Queue
 from configfile import error
 from klippy import Printer
 
@@ -167,8 +169,9 @@ class afc:
         # save_vars() only builds the state dict on the reactor thread; the actual file
         # write happens on this background thread so a slow disk can't stall Klipper.
         # A single worker (rather than a thread per call) keeps writes ordered.
-        self._var_write_queue: queue.Queue = queue.Queue()
-        self._var_write_thread = threading.Thread(target=self._var_write_worker, daemon=True)
+        self._var_write_queue: Queue = Queue()
+        self._var_write_thread = threading.Thread(target=self._var_write_worker, daemon=True,
+                                                  name="afc_save_vars")
         self._var_write_thread.start()
         self.default_material_temps = config.getlists("default_material_temps",
                                                       ("default: 235", "PLA:210", "PETG:235", "ABS:235", "ASA:235"))# Default temperature to set extruder when loading/unloading lanes. Material needs to be either manually set or uses material from spoolman if extruder temp is not set in spoolman.
@@ -1331,6 +1334,12 @@ class afc:
         writes them to VarFile.unit file in the order they were queued. Runs for
         the life of the process (daemon thread) so it needs no explicit shutdown.
         """
+        try:
+            thread_name = threading.current_thread().name
+            chelper.get_ffi()[1].set_thread_name(thread_name.encode("utf-8"))
+        except:
+            pass
+
         while True:
             data = self._var_write_queue.get()
             self._write_vars_snapshot(data)

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -413,7 +413,7 @@ class afc:
         """
 
         try:
-            self.moonraker = AFC_moonraker( self.moonraker_host, self.moonraker_port, self.logger )
+            self.moonraker = AFC_moonraker( self.moonraker_host, self.moonraker_port, self.logger, self.reactor )
             if not self.moonraker.wait_for_moonraker( toolhead=self.toolhead, timeout=self.moonraker_connect_to ):
                 return False
 

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -4,6 +4,7 @@
 #
 from __future__ import annotations
 
+import os
 import json
 import re
 import traceback
@@ -1358,8 +1359,16 @@ class afc:
         :param data: Dictionary of lane/unit/system state to write to VarFile.unit
         """
         try:
-            with open(self.VarFile + '.unit', 'w') as f:
+            # Writing to temp directory first and them renaming to correct file so that a file
+            # does not get half written if klipper decides to crash in the middle of AFC writing
+            # to file.
+            target_file = self.VarFile + '.unit'
+            temp_path = target_file + ".tmp"
+            with open(temp_path, 'w') as f:
                 f.write(json.dumps(data, indent=4))
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(temp_path, target_file)
         except Exception as e:
             err = f"Error:{e}\n{traceback.format_exc()}"
             # Push back onto the reactor thread before logging: AFC_logger

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -82,6 +82,7 @@ def load_config(config):
     return afc(config)
 
 class afc:
+    class sentinel: pass
     def __init__(self, config: ConfigWrapper):
         self.config  = config
         self.printer = config.get_printer()
@@ -89,6 +90,7 @@ class afc:
         self.webhooks = self.printer.load_object(config, 'webhooks')
         self.printer.register_event_handler("klippy:connect",self.handle_connect)
         self.printer.register_event_handler("klippy:ready", self.handle_ready)
+        self.printer.register_event_handler("klippy:disconnect", self.join_threads)
         self.logger  = AFC_logger(self.printer, self)
 
         self.function: afcFunction = self.printer.load_object(config, 'AFC_functions')
@@ -170,6 +172,7 @@ class afc:
         # save_vars() only builds the state dict on the reactor thread; the actual file
         # write happens on this background thread so a slow disk can't stall Klipper.
         # A single worker is created rather than a thread per call to keep writes ordered.
+        self._var_write_thread_wait = True
         self._var_write_queue: Queue = Queue()
         self._var_write_thread = threading.Thread(target=self._var_write_worker, daemon=True,
                                                   name="afc_save_vars")
@@ -1334,6 +1337,17 @@ class afc:
         # block the reactor; queue.put_nowait never blocks the caller here
         self._var_write_queue.put_nowait(str)
 
+    def join_threads(self) -> None:
+        """
+        Method is called when a klipper:disconnect happens so that all threads can be cleaned up
+        correctly
+        """
+        self._var_write_queue.put_nowait(self.sentinel)
+        self._var_write_thread_wait = False
+        self._var_write_thread.join()
+        if self.moonraker is not None:
+            self.moonraker.join_thread()
+
     def _var_write_worker(self) -> None:
         """
         Background thread loop that pulls queued save_vars() values and
@@ -1346,8 +1360,10 @@ class afc:
         except:
             pass
 
-        while True:
+        while self._var_write_thread_wait:
             data = self._var_write_queue.get()
+            if data is self.sentinel:
+                return
             self._write_vars_snapshot(data)
 
     def _write_vars_snapshot(self, data: dict) -> None:

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -659,7 +659,7 @@ class afc:
             self.number_of_toolchanges = 0
             if (self.moonraker is not None
                 and self.print_data_metadata):
-                self.print_data_metadata.query_filename(print_filename, on_ready=self._finish_print_start)
+                self.print_data_metadata.query_filename(print_filename, on_fetched=self._finish_print_start)
             else:
                 self._finish_print_start()
 

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -645,7 +645,10 @@ class afc:
         """
         Print timer callback to check if printer is currently in a print. If printer is in a print,
         current filename is looked up and metadata is pulled from moonraker to get total filament change
-        count and per-tool temperatures. Once this is done timer callback is stopped and unregistered.
+        count and per-tool temperatures. Metadata is fetched asynchronously since this reactor timer runs
+        while printing and can't block on the HTTP round trip to moonraker; _finish_print_start runs once
+        it's ready (or immediately if there's no moonraker to query). Once this is done timer callback is
+        stopped and unregistered.
         """
         # Remove timer from reactor
         self.reactor.unregister_timer(self.in_print_timer)
@@ -656,20 +659,35 @@ class afc:
             self.number_of_toolchanges = 0
             if (self.moonraker is not None
                 and self.print_data_metadata):
-                self.print_data_metadata.filename = print_filename
-                self.number_of_toolchanges = self.print_data_metadata.tool_change_count
-                self.print_tool_temperatures = self.print_data_metadata.tool_temperatures
-            self.current_toolchange     = -1 # Reset
-            self.logger.info("Total number of toolchanges set to {}".format(self.number_of_toolchanges))
-
-            # Get current lane and update position to reset fault detection as sometimes
-            # purging in PRINT_START can lead to false positive detections
-            current_lane = self.function.get_current_lane_obj()
-            if current_lane:
-                if current_lane.buffer_obj is not None:
-                    current_lane.buffer_obj.update_filament_error_pos()
+                self.print_data_metadata.query_filename(print_filename, on_ready=self._finish_print_start)
+            else:
+                self._finish_print_start()
 
         return self.reactor.NEVER
+
+    def _finish_print_start(self) -> None:
+        """
+        Completes print-start bookkeeping: applies the toolchange count/per-tool
+        temperatures cached by print_data_metadata (if a query was made), resets
+        current_toolchange, and resets the current lane's fault-detection position.
+
+        Runs either immediately from in_print_reactor_timer (no moonraker/
+        print_data_metadata to query) or as the completion callback once
+        print_data_metadata.query_filename() finishes fetching metadata.
+        """
+        if (self.moonraker is not None
+            and self.print_data_metadata):
+            self.number_of_toolchanges = self.print_data_metadata.tool_change_count
+            self.print_tool_temperatures = self.print_data_metadata.tool_temperatures
+        self.current_toolchange     = -1 # Reset
+        self.logger.info("Total number of toolchanges set to {}".format(self.number_of_toolchanges))
+
+        # Get current lane and update position to reset fault detection as sometimes
+        # purging in PRINT_START can lead to false positive detections
+        current_lane = self.function.get_current_lane_obj()
+        if current_lane:
+            if current_lane.buffer_obj is not None:
+                current_lane.buffer_obj.update_filament_error_pos()
 
     def _get_default_material_temps(self, cur_lane):
         """

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -168,7 +168,7 @@ class afc:
 
         # save_vars() only builds the state dict on the reactor thread; the actual file
         # write happens on this background thread so a slow disk can't stall Klipper.
-        # A single worker (rather than a thread per call) keeps writes ordered.
+        # A single worker is created rather than a thread per call to keep writes ordered.
         self._var_write_queue: Queue = Queue()
         self._var_write_thread = threading.Thread(target=self._var_write_worker, daemon=True,
                                                   name="afc_save_vars")
@@ -416,8 +416,10 @@ class afc:
         """
 
         try:
-            self.moonraker = AFC_moonraker( self.moonraker_host, self.moonraker_port, self.logger, self.reactor )
-            if not self.moonraker.wait_for_moonraker( toolhead=self.toolhead, timeout=self.moonraker_connect_to ):
+            self.moonraker = AFC_moonraker(self.moonraker_host, self.moonraker_port, self.logger,
+                                           self.reactor)
+            if not self.moonraker.wait_for_moonraker(toolhead=self.toolhead,
+                                                     timeout=self.moonraker_connect_to):
                 return False
 
             # Remove current lane_data from database before pushing data back up so that
@@ -648,9 +650,11 @@ class afc:
         """
         Print timer callback to check if printer is currently in a print. If printer is in a print,
         current filename is looked up and metadata is pulled from moonraker to get total filament change
-        count and per-tool temperatures. Metadata is fetched asynchronously since this reactor timer runs
-        while printing and can't block on the HTTP round trip to moonraker; _finish_print_start runs once
-        it's ready (or immediately if there's no moonraker to query). Once this is done timer callback is
+        count and per-tool temperatures.
+
+        Metadata is fetched asynchronously since this reactor timer runs while printing and shouldn't
+        block on the HTTP round trip to moonraker. _finish_print_start runs once it's ready
+        (or immediately if there's no moonraker to query). Once this is done timer callback is
         stopped and unregistered.
         """
         # Remove timer from reactor
@@ -662,7 +666,8 @@ class afc:
             self.number_of_toolchanges = 0
             if (self.moonraker is not None
                 and self.print_data_metadata):
-                self.print_data_metadata.query_filename(print_filename, on_fetched=self._finish_print_start)
+                self.print_data_metadata.query_filename(print_filename,
+                                                        on_fetched=self._finish_print_start)
             else:
                 self._finish_print_start()
 
@@ -670,13 +675,13 @@ class afc:
 
     def _finish_print_start(self) -> None:
         """
-        Completes print-start bookkeeping: applies the toolchange count/per-tool
-        temperatures cached by print_data_metadata (if a query was made), resets
+        Completes print-start moonraker file metadata query: applies the toolchange count and
+        per-tool temperatures cached by print_data_metadata (if a query was made). Resets
         current_toolchange, and resets the current lane's fault-detection position.
 
-        Runs either immediately from in_print_reactor_timer (no moonraker/
-        print_data_metadata to query) or as the completion callback once
-        print_data_metadata.query_filename() finishes fetching metadata.
+        Runs either immediately from in_print_reactor_timer (no moonraker/print_data_metadata to
+        query) or from the completion callback once print_data_metadata.query_filename()
+        finishes fetching metadata.
         """
         if (self.moonraker is not None
             and self.print_data_metadata):

--- a/extras/AFC.py
+++ b/extras/AFC.py
@@ -56,7 +56,7 @@ except: raise error(ERROR_STR.format(import_lib="AFC_utils", trace=traceback.for
 try: from extras.AFC_stats import AFCStats
 except: raise error(ERROR_STR.format(import_lib="AFC_stats", trace=traceback.format_exc()))
 
-AFC_VERSION="1.2.6"
+AFC_VERSION="1.2.7"
 
 # Class for holding different states so its clear what all valid states are
 class State(str, Enum):

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -784,19 +784,34 @@ class afcFunction:
         :param print_error: Prints error message to logger if set to True
         :return bool,str: Returns tuple of True/False, error message if error occurred
         '''
+        td1_data = self.afc.moonraker.get_td1_data()
+        return self._check_td1_error_in_data(td1_data, serial_number, print_error)
+
+    def _check_td1_error_in_data(self, td1_data: Optional[dict], serial_number: Optional[str] = None,
+                                 print_error: bool = True) -> tuple[bool, str]:
+        '''
+        Checks an already-fetched TD-1 devices dict for errors, without
+        fetching it itself.
+
+        :param td1_data: TD-1 devices dict already fetched, None if the fetch failed
+        :param serial_number: Specific serial number to check for error
+        :param print_error: Prints error message to logger if set to True
+        :return bool,str: Returns tuple of True/False, error message if error occurred
+        '''
         error_occurred = False
         error_message = ""
-        td1_data = self.afc.moonraker.get_td1_data()
-        for serial in td1_data:
-            error = td1_data[serial].get("error")
-            if error is not None:
-                if serial_number is None or serial == serial_number:
-                    error_message = f"Error with TD-1 Serial: {serial}, please fix error with TD-1 and run 'AFC_RESET_TD1 SERIAL={serial}' macro.\n"
-                    error_message += "Some errors can occur when first booting machine and filament is in TD-1 device\n"
-                    error_message += f"Reported Error: {td1_data[serial]['error']}"
-                    error_occurred = True
-                    if print_error:
-                        self.logger.error(error_message)
+        if td1_data is not None:
+            for serial in td1_data:
+                error = td1_data[serial].get("error")
+                if error is not None:
+                    if (serial_number is None
+                        or serial == serial_number):
+                        error_message = f"Error with TD-1 Serial: {serial}, please fix error with TD-1 and run 'AFC_RESET_TD1 SERIAL={serial}' macro.\n"
+                        error_message += "Some errors can occur when first booting machine and filament is in TD-1 device\n"
+                        error_message += f"Reported Error: {td1_data[serial]['error']}"
+                        error_occurred = True
+                        if print_error:
+                            self.logger.error(error_message)
         return error_occurred, error_message
 
     def check_for_td1_id(self, serial_number):
@@ -809,10 +824,23 @@ class afcFunction:
                           str: error message if device does not exist or an error with TD-1 device
         """
         td1_data = self.afc.moonraker.get_td1_data()
-        if serial_number not in td1_data:
+        return self._check_td1_id_in_data(td1_data, serial_number)
+
+    def _check_td1_id_in_data(self, td1_data: Optional[dict], serial_number: Optional[str]) -> tuple[bool, str]:
+        """
+        Validates a serial number against an already-fetched TD-1 devices dict,
+        without fetching it itself.
+
+        :param td1_data: TD-1 devices dict already fetched, None if the fetch failed
+        :param serial_number: Serial number to check for
+        :return bool,str: bool: True if device exists/False if device does not exist or error with device
+                          str: error message if device does not exist or an error with TD-1 device
+        """
+        if (td1_data is None
+            or serial_number not in td1_data):
             return False, f"TD-1 Device ID ({serial_number}) supplied but ID not found."
 
-        no_error, error_message = self.check_for_td1_error(serial_number, print_error=False)
+        no_error, error_message = self._check_td1_error_in_data(td1_data, serial_number, print_error=False)
         return not no_error, error_message
 
     def gcode_get_value( self, gcmd, get_attr, variable, variable_name, section_name, key_name=None, cast_to_bool=False ):

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -1954,18 +1954,32 @@ class AFCLane:
 
         self._sent_lane_data_keys = current_keys
 
-    def get_td1_data_load(self):
+    def get_td1_data_load(self) -> None:
         """
         Captures TD-1 data for a lane after being loaded into toolhead. When capturing
         data scan time is ignored as its assumed its scanned when loaded into toolhead.
+        Fetches TD-1 data asynchronously since this runs at the end of every TOOL_LOAD
+        and can't block on the HTTP round trip during a print.
         """
-        if self.afc.td1_present:
-            valid = False
-            if self.td1_device_id:
-                valid, _ = self.afc.function.check_for_td1_id(self.td1_device_id)
+        if not self.afc.td1_present:
+            return
+        if not self.td1_device_id:
+            return
+        if self.afc.moonraker is None:
+            return
+        self.afc.moonraker.get_td1_data_async(self._apply_td1_data_load)
 
-            if valid:
-                self.unit_obj.get_td1_data(self, datetime.now(), ignore_time=True)
+    def _apply_td1_data_load(self, devices: Optional[dict]) -> None:
+        """
+        Completion callback for get_td1_data_load()'s async TD-1 fetch. Validates
+        the configured device ID against the fetched data, then applies it to this lane.
+        Runs on the reactor thread.
+
+        :param devices: TD-1 devices dict fetched asynchronously, or None on failure
+        """
+        valid, _ = self.afc.function._check_td1_id_in_data(devices, self.td1_device_id)
+        if valid:
+            self.unit_obj._apply_td1_data(self, datetime.now(), devices, ignore_time=True)
 
     def get_td1_data(self):
         """

--- a/extras/AFC_lane.py
+++ b/extras/AFC_lane.py
@@ -1323,7 +1323,14 @@ class AFCLane:
                                 self.logger.debug(f"Prep: direct load logic-{self.name}-{self.hub}")
                                 if not self.afc.TOOL_LOAD(self):
                                     self.afc.afc_stats.increase_load_error_count(self.afc)
-                                self.afc.spool._set_values(self)
+                                # TOOL_LOAD already pushed the active spool to Spoolman using
+                                # whatever spool_id was set before this point. _set_values can
+                                # still be waiting on an async Spoolman fetch (from a next_spool_id
+                                # set by e.g. an NFC scan) that updates spool_id afterward, so
+                                # re-push once that settles rather than leaving Spoolman pointed
+                                # at the stale value TOOL_LOAD saw.
+                                self.afc.spool._set_values(
+                                    self, on_done=lambda: self.afc.spool.set_active_spool(self.spool_id))
                                 self.logger.debug(f"Prep: direct load logic done-{self.name}-{self.hub}")
                                 break
 

--- a/extras/AFC_spool.py
+++ b/extras/AFC_spool.py
@@ -642,9 +642,13 @@ class AFCSpool:
             value = filament[field]
         return value
 
-    def _set_values(self, cur_lane: AFCLane) -> None:
+    def _set_values(self, cur_lane: AFCLane, on_done: Optional[Callable[[], None]] = None) -> None:
         """
         Helper function for setting lane spool values
+
+        :param on_done: Called once this lane's spool values have actually settled, called
+                        immediately if there's no next_spool_id to apply, or once set_spoolID's
+                        async fetch resolves
         """
         # Always reset debounce on spool change
         cur_lane.auto_switch_triggered = False
@@ -662,7 +666,9 @@ class AFCSpool:
             and self.next_spool_id is not None):
             spool_id = self.next_spool_id
             self.next_spool_id = None
-            self.set_spoolID(cur_lane, spool_id)
+            self.set_spoolID(cur_lane, spool_id, on_done=on_done)
+        elif on_done is not None:
+            on_done()
 
     def clear_values(self, cur_lane: AFCLane) -> None:
         """

--- a/extras/AFC_spool.py
+++ b/extras/AFC_spool.py
@@ -6,7 +6,7 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 from __future__ import annotations
 
-from typing import Optional, Union, Any, TYPE_CHECKING
+from typing import Optional, Union, Any, Callable, TYPE_CHECKING
 import copy
 import traceback
 import re
@@ -612,11 +612,21 @@ class AFCSpool:
                     self.logger.error(f"SpoolId {SpoolID} already assigned to a lane, cannot assign to {lane}.")
                     return
 
-            self.set_spoolID(cur_lane, SpoolID)
+            # Updating the active spool in Spoolman needs to wait for set_spoolID's
+            # async fetch to actually apply the new spool_id to the lane first
+            self.set_spoolID(cur_lane, SpoolID,
+                             on_done=lambda: self._update_active_spool_if_current(cur_lane))
 
-            # If the lane is currently loaded to the toolhead, update the active spool in Spoolman
-            if cur_lane.name == self.afc.current:
-                self.set_active_spool(cur_lane.spool_id)
+    def _update_active_spool_if_current(self, cur_lane: AFCLane) -> None:
+        """
+        Pushes a lane's spool ID to Spoolman as the active spool if this lane
+        is currently loaded to the toolhead. Runs as set_spoolID()'s on_done
+        callback, once the (possibly async) spool assignment has finished.
+
+        :param cur_lane: Lane that was just assigned/cleared a spool ID
+        """
+        if cur_lane.name == self.afc.current:
+            self.set_active_spool(cur_lane.spool_id)
 
     def _get_filament_values( self, filament: dict, field: str, default: Any=None) -> Any:
         """
@@ -671,74 +681,36 @@ class AFCSpool:
         cur_lane.filament_name = ""
 
     def set_spoolID(self, cur_lane: AFCLane, SpoolID: Optional[Union[int, str]],
-                    save_vars: bool = True) -> None:
+                    save_vars: bool = True, on_done: Optional[Callable[[], None]] = None) -> None:
         """
         Assigns a spool from Spoolman to a lane, pulling material, color, weight,
         and temperature values from Spoolman and updating the lane accordingly.
         Clears the lane's values instead when SpoolID is empty/None and the lane
-        isn't set to remember its spool.
+        isn't set to remember its spool. Fetching Spoolman data is async (see
+        _apply_spool_data) since this can be called from a load sequence and
+        can't block on the HTTP round trip.
 
         :param cur_lane:  AFC lane to assign the spool to
         :param SpoolID:   Spoolman spool ID to assign, or None/'' to clear
         :param save_vars: Whether to save AFC vars after assigning
+        :param on_done:   Called once this lane's spool data has actually been
+                          applied (immediately for the synchronous branches
+                          below, or once the async Spoolman fetch resolves)
         """
         if (self.afc.spoolman is not None
             and self.afc.moonraker is not None):
             if (SpoolID is not None
                 and SpoolID != ''):
+                spool_id_value: Union[int, str] = SpoolID
                 try:
-                    result = self.afc.moonraker.get_spool(int(SpoolID))
-                    cur_lane.spool_id = SpoolID
-                    cur_lane.auto_switch_triggered = False
-
-                    cur_lane.material           = self._get_filament_values(result['filament'], 'material')
-                    if not self.afc.ignore_spoolman_material_temps:
-                        cur_lane.extruder_temp      = self._get_filament_values(result['filament'], 'settings_extruder_temp')
-                    cur_lane.bed_temp           = self._get_filament_values(result['filament'], 'settings_bed_temp')
-                    cur_lane.filament_density   = self._get_filament_values(result['filament'], 'density')
-                    cur_lane.filament_diameter  = self._get_filament_values(result['filament'], 'diameter')
-                    cur_lane.empty_spool_weight = self._get_filament_values(result, 'spool_weight', default=190)
-                    cur_lane.weight             = self._get_filament_values(result, 'remaining_weight')
-                    full_weight                 = self._get_filament_values(result, 'initial_weight', default=1000)
-                    cur_lane.espooler.espooler_values.full_weight = full_weight
-                    cur_lane.filament_name      = self._get_filament_values(result['filament'], 'name', default="")
-
-                    vendor_result  = result["filament"].get("vendor", None)
-                    cur_lane.spool_vendor       = ""
-                    if vendor_result:
-                        cur_lane.spool_vendor   = self._get_filament_values(vendor_result, "name", None)
-
-                    weight_check = self.disable_weight_check
-
-                    self.afc.logger.debug(f"Weight remaining for SpoolID {SpoolID}: {cur_lane.weight}")
-
-                    if not weight_check:
-                        if (cur_lane.weight is None
-                            or cur_lane.weight <= 0):
-                            error_str = (f"Invalid weight for spoolID: {SpoolID}. "
-                                        "Please check remaining weight before assigning.")
-                            self.afc.error.AFC_error(error_str, False)
-                            self.clear_values(cur_lane)
-                            return
-
-                    # Check to see if filament is defined as multi-color and take the first color for now
-                    # Once support for multicolor is added this needs to be updated
-                    multi_color_hex = self._get_filament_values(result['filament'], 'multi_color_hexes')
-                    if multi_color_hex:
-                        cur_lane.multi_color = multi_color_hex.split(",")
-                        cur_lane.color = f"#{cur_lane.multi_color[0]}"
-                    else:
-                        cur_lane.color = f"#{self._get_filament_values(result['filament'], 'color_hex')}"
-                        cur_lane.multi_color = []
-
-                    cur_lane.send_lane_data()
-                    # Refresh LED only if filament is loaded — empty lanes keep their state color
-                    if (cur_lane.load_state
-                        and cur_lane.unit in self.afc.units):
-                        cur_lane.unit_obj.lane_loaded(cur_lane, force=True)
-
+                    spool_id_int = int(SpoolID)
                 except Exception as e:
                     self.afc.error.AFC_error(f"Error when trying to get Spoolman data for ID:{SpoolID}, Error: {e}", False)
+                else:
+                    self.afc.moonraker.get_spool(
+                        spool_id_int,
+                        lambda result: self._apply_spool_data(cur_lane, spool_id_value, result, save_vars, on_done))
+                    return
             elif not cur_lane.remember_spool:
                 self.clear_values(cur_lane)
         elif not cur_lane.remember_spool:
@@ -748,6 +720,90 @@ class AFCSpool:
 
         self.set_snapmaker_filament_params(cur_lane)
 
+        if save_vars: self.afc.save_vars()
+        if on_done is not None:
+            on_done()
+
+    def _apply_spool_data(self, cur_lane: AFCLane, SpoolID: Union[int, str],
+                          result: Optional[dict], save_vars: bool,
+                          on_done: Optional[Callable[[], None]] = None) -> None:
+        """
+        Applies a Spoolman spool lookup result to a lane: material, color,
+        weight, temperatures, etc. Runs as the completion callback for
+        set_spoolID()'s async fetch, once moonraker's response arrives.
+
+        :param cur_lane:  AFC lane to assign the spool to
+        :param SpoolID:   Spoolman spool ID that was queried
+        :param result:    Spool data dict returned by moonraker, None on failure
+        :param save_vars: Whether to save AFC vars after assigning
+        :param on_done:   Called once this attempt to apply spool data is finished,
+                          on every exit path (success, invalid weight, or error)
+        """
+        try:
+            try:
+                if result is None:
+                    raise ValueError(f"No spool data returned for SpoolID {SpoolID}")
+
+                cur_lane.spool_id = SpoolID
+                cur_lane.auto_switch_triggered = False
+
+                cur_lane.material           = self._get_filament_values(result['filament'], 'material')
+                if not self.afc.ignore_spoolman_material_temps:
+                    cur_lane.extruder_temp      = self._get_filament_values(result['filament'], 'settings_extruder_temp')
+                cur_lane.bed_temp           = self._get_filament_values(result['filament'], 'settings_bed_temp')
+                cur_lane.filament_density   = self._get_filament_values(result['filament'], 'density')
+                cur_lane.filament_diameter  = self._get_filament_values(result['filament'], 'diameter')
+                cur_lane.empty_spool_weight = self._get_filament_values(result, 'spool_weight', default=190)
+                cur_lane.weight             = self._get_filament_values(result, 'remaining_weight')
+                full_weight                 = self._get_filament_values(result, 'initial_weight', default=1000)
+                cur_lane.espooler.espooler_values.full_weight = full_weight
+                cur_lane.filament_name      = self._get_filament_values(result['filament'], 'name', default="")
+
+                vendor_result  = result["filament"].get("vendor", None)
+                cur_lane.spool_vendor       = ""
+                if vendor_result:
+                    cur_lane.spool_vendor   = self._get_filament_values(vendor_result, "name", None)
+
+                weight_check = self.disable_weight_check
+
+                self.afc.logger.debug(f"Weight remaining for SpoolID {SpoolID}: {cur_lane.weight}")
+
+                if not weight_check:
+                    if (cur_lane.weight is None
+                        or cur_lane.weight <= 0):
+                        error_str = (f"Invalid weight for spoolID: {SpoolID}. "
+                                    "Please check remaining weight before assigning.")
+                        self.afc.error.AFC_error(error_str, False)
+                        self.clear_values(cur_lane)
+                        return
+
+                # Check to see if filament is defined as multi-color and take the first color for now
+                # Once support for multicolor is added this needs to be updated
+                multi_color_hex = self._get_filament_values(result['filament'], 'multi_color_hexes')
+                if multi_color_hex:
+                    cur_lane.multi_color = multi_color_hex.split(",")
+                    cur_lane.color = f"#{cur_lane.multi_color[0]}"
+                else:
+                    cur_lane.color = f"#{self._get_filament_values(result['filament'], 'color_hex')}"
+                    cur_lane.multi_color = []
+
+                cur_lane.send_lane_data()
+                # Refresh LED only if filament is loaded — empty lanes keep their state color
+                if (cur_lane.load_state
+                    and cur_lane.unit in self.afc.units):
+                        cur_lane.unit_obj.lane_loaded(cur_lane, force=True)
+
+            except Exception as e:
+                self.afc.error.AFC_error(f"Error when trying to get Spoolman data for ID:{SpoolID}, Error: {e}", False)
+        finally:
+            # Runs on every exit path (early return, exception, or the happy
+            # path) so on_done fires exactly once regardless of which branch
+            # was taken -- matching the original synchronous behavior where
+            # callers resumed right after set_spoolID() returned either way.
+            if on_done is not None:
+                on_done()
+
+        self.set_snapmaker_filament_params(cur_lane)
         if save_vars: self.afc.save_vars()
 
     cmd_SET_RUNOUT_help = "Set runout lane"

--- a/extras/AFC_spool.py
+++ b/extras/AFC_spool.py
@@ -797,15 +797,14 @@ class AFCSpool:
             except Exception as e:
                 self.afc.error.AFC_error(f"Error when trying to get Spoolman data for ID:{SpoolID}, Error: {e}", False)
         finally:
+            self.set_snapmaker_filament_params(cur_lane)
+            if save_vars: self.afc.save_vars()
             # Runs on every exit path (early return, exception, or the happy
             # path) so on_done fires exactly once regardless of which branch
             # was taken -- matching the original synchronous behavior where
             # callers resumed right after set_spoolID() returned either way.
             if on_done is not None:
                 on_done()
-
-        self.set_snapmaker_filament_params(cur_lane)
-        if save_vars: self.afc.save_vars()
 
     cmd_SET_RUNOUT_help = "Set runout lane"
     def cmd_SET_RUNOUT(self, gcmd: GCodeCommand) -> None:

--- a/extras/AFC_spool.py
+++ b/extras/AFC_spool.py
@@ -621,7 +621,7 @@ class AFCSpool:
         """
         Pushes a lane's spool ID to Spoolman as the active spool if this lane
         is currently loaded to the toolhead. Runs as set_spoolID()'s on_done
-        callback, once the (possibly async) spool assignment has finished.
+        callback, once the spool data has been fetched and assignment has finished.
 
         :param cur_lane: Lane that was just assigned/cleared a spool ID
         """
@@ -688,7 +688,7 @@ class AFCSpool:
         Clears the lane's values instead when SpoolID is empty/None and the lane
         isn't set to remember its spool. Fetching Spoolman data is async (see
         _apply_spool_data) since this can be called from a load sequence and
-        can't block on the HTTP round trip.
+        shouldn't block on the HTTP round trip.
 
         :param cur_lane:  AFC lane to assign the spool to
         :param SpoolID:   Spoolman spool ID to assign, or None/'' to clear
@@ -714,7 +714,8 @@ class AFCSpool:
             elif not cur_lane.remember_spool:
                 self.clear_values(cur_lane)
         elif not cur_lane.remember_spool:
-            # Clears out values if users are not using spoolman and lane isn't set to remember spool, this is to cover this function being called from LANE UNLOAD and clearing out
+            # Clears out values if users are not using spoolman and lane isn't set to remember spool,
+            # this is to cover this function being called from LANE UNLOAD and clearing out
             # Manually entered information
             self.clear_values(cur_lane)
 

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -849,10 +849,28 @@ class afcUnit:
         :return boolean: True once filament is detected in TD-1 device
         """
         td1_data = self.afc.moonraker.get_td1_data()
+        return self._apply_td1_data(cur_lane, compare_time, td1_data, ignore_time)
+
+    def _apply_td1_data(self, cur_lane: AFCLane, compare_time: datetime,
+                        td1_data: Optional[dict], ignore_time: bool=False) -> bool:
+        """
+        Validates and applies an already-fetched TD-1 data payload to a lane,
+        without fetching it itself.
+
+        :param cur_lane: Current lane to apply TD-1 data to, also check's to see if lane has a specific TD-1 ID
+                         assigned to the lane.
+        :param compare_time: Time to compare returned data to, which helps verify that the data is valid and
+                             filament has reached TD-1 device
+        :param td1_data: TD-1 devices dict already fetched, None if the fetch failed
+        :param ignore_time: Override to just capture TD-1 data anyways, useful when loading filament to toolhead
+                            and want to capture data once loaded.
+
+        :return boolean: True once filament is detected in TD-1 device
+        """
         t_delta = timedelta(seconds = 10)
         valid_data = False
 
-        if len(td1_data) > 0:
+        if td1_data is not None and len(td1_data) > 0:
             self.logger.debug(f"Data: {td1_data}, Compare_time: {compare_time}")
 
             if cur_lane.td1_device_id in td1_data:
@@ -886,6 +904,7 @@ class afcUnit:
                 self.logger.info(f"{cur_lane.name} TD-1 data captured")
                 self.afc.save_vars()
                 return True
+        return False
 
     def prep_load(self, lane: AFCLane):
         """

--- a/extras/AFC_utils.py
+++ b/extras/AFC_utils.py
@@ -602,14 +602,28 @@ class AFC_moonraker:
             self._log_async(self.logger.error,
                             f"Error when trying to update {key} in moonraker, see AFC.log for more info")
 
-    def get_spool(self, id:int):
+    def get_spool(self, id: int, callback: Callable[[Optional[dict]], None]) -> None:
         """
-        Uses moonrakers proxy to query spoolID from spoolman
+        Queues a query for a spool's data from spoolman (via moonrakers proxy)
+        to run on the background writer thread. Runs asynchronously because
+        this can be called from a load sequence and can't block on the HTTP
+        round trip.
 
         :param id: SpoolID to lookup and fetch data from spoolman
-        :return: Returns dictionary of spoolID, returns None if error occurred or ID does not exist
+        :param callback: Called with the spool data dict (or None if error
+                         occurred or ID does not exist) once the query completes.
+                         Runs on the reactor thread.
         """
-        resp = None
+        self._write_queue.put_nowait((self._get_spool_sync, (id, callback)))
+
+    def _get_spool_sync(self, id: int, callback: Callable[[Optional[dict]], None]) -> None:
+        """
+        Does the actual GET for a spool's data from spoolman. Called from the
+        background writer thread; schedules callback on the reactor thread.
+
+        :param id: SpoolID to lookup and fetch data from spoolman
+        :param callback: Called with the spool data dict (or None on failure)
+        """
         request_payload = {
             "request_method": "GET",
             "path": f"/v1/spool/{id}"
@@ -618,11 +632,9 @@ class AFC_moonraker:
         req = Request( spool_url, urlencode(request_payload).encode() )
 
         resp = self._get_results(req)
-        if resp is not None:
-            resp = resp
-        else:
-            self.logger.info(f"SpoolID: {id} not found")
-        return resp
+        if resp is None:
+            self._log_async(self.logger.info, f"SpoolID: {id} not found")
+        self.reactor.register_async_callback(lambda et, resp=resp: callback(resp))
 
     def check_for_td1(self):
         """
@@ -806,7 +818,7 @@ class AFC_PrintFileMetaData:
         """
         return self._filename
 
-    def query_filename(self, value: str, on_ready: Optional[Callable[[], None]] = None) -> None:
+    def query_filename(self, value: str, on_fetched: Optional[Callable[[], None]] = None) -> None:
         """
         Sets current filename and queues a moonraker query for its metadata,
         caching the result for the `tool_change_count`/`tool_temperatures`
@@ -815,20 +827,20 @@ class AFC_PrintFileMetaData:
         the HTTP round trip.
 
         :param value: Filename to query moonraker and pull metadata for
-        :param on_ready: Called (on the reactor thread) once metadata has been
-                         fetched and cached, or immediately if there's nothing
-                         to fetch
+        :param on_fetched: Called (on the reactor thread) once metadata has been
+                           fetched and cached, or immediately if there's nothing
+                           to fetch
         """
         self._filename = value
         if (self._moonraker
             and value):
             self._moonraker.get_file_metadata(
-                value, lambda resp: self._apply_metadata(value, resp, on_ready))
-        elif on_ready is not None:
-            on_ready()
+                value, lambda resp: self._apply_metadata(value, resp, on_fetched))
+        elif on_fetched is not None:
+            on_fetched()
 
     def _apply_metadata(self, filename: str, resp: Optional[dict],
-                        on_ready: Optional[Callable[[], None]]) -> None:
+                        on_fetched: Optional[Callable[[], None]]) -> None:
         """
         Caches a metadata query result, guarding against a stale response
         landing after filename has since changed again (e.g. the print ended
@@ -836,12 +848,12 @@ class AFC_PrintFileMetaData:
 
         :param filename: Filename this response was fetched for
         :param resp: Metadata dict returned by moonraker, or None on failure
-        :param on_ready: Called once cached, if provided
+        :param on_fetched: Called once cached, if provided
         """
         if filename == self._filename:
             self._metadata = resp or {}
-        if on_ready is not None:
-            on_ready()
+        if on_fetched is not None:
+            on_fetched()
 
     @property
     def tool_change_count(self) -> int:

--- a/extras/AFC_utils.py
+++ b/extras/AFC_utils.py
@@ -670,7 +670,7 @@ class AFC_moonraker:
     def get_td1_data(self):
         """
         Synchronous fetch for TD-1 data from moonrakers `machine/td1/data` endpoint.
-        
+
         See get_td1_data_async() for the non-blocking version.
 
         :returns dict: Returns dictionary of TD-1 devices by serial numbers with their data,
@@ -689,7 +689,7 @@ class AFC_moonraker:
         Queues a query for TD-1 device data to run on the background writer
         thread. Runs asynchronously because for situations where a fetch cannot
         block on the HTTP round trip during a print (eg. during a toolchange when printing).
-        
+
         See get_td1_data() for the synchronous version.
 
         :param callback: Called with the TD-1 devices dict (or None on failure)

--- a/extras/AFC_utils.py
+++ b/extras/AFC_utils.py
@@ -396,6 +396,7 @@ class AFC_moonraker:
         AFC logger object to log and print to console
     """
     ERROR_STRING = "Error getting data from moonraker, check AFC.log for more information"
+    REQUEST_TIMEOUT = 10
     def __init__(self, host: str, port: str, logger: AFC_logger, reactor: Reactor):
         self.port           = port
         self.logger         = logger
@@ -470,7 +471,7 @@ class AFC_moonraker:
             logger = self.logger.debug
 
         try:
-            resp = urlopen(url_string)
+            resp = urlopen(url_string, timeout=self.REQUEST_TIMEOUT)
             if resp.status >= 200 and resp.status <= 300:
                 data = json.load(resp)
             else:
@@ -668,7 +669,9 @@ class AFC_moonraker:
 
     def get_td1_data(self):
         """
-        Fetches TD-1 data from moonrakers `machine/td1/data` endpoint
+        Synchronous fetch for TD-1 data from moonrakers `machine/td1/data` endpoint.
+        
+        See get_td1_data_async() for the non-blocking version.
 
         :returns dict: Returns dictionary of TD-1 devices by serial numbers with their data,
                        returns None if no TD-1 devices are found
@@ -680,6 +683,32 @@ class AFC_moonraker:
             return resp["devices"]
         else:
             return None
+
+    def get_td1_data_async(self, callback: Callable[[Optional[dict]], None]) -> None:
+        """
+        Queues a query for TD-1 device data to run on the background writer
+        thread. Runs asynchronously because for situations where a fetch cannot
+        block on the HTTP round trip during a print (eg. during a toolchange when printing).
+        
+        See get_td1_data() for the synchronous version.
+
+        :param callback: Called with the TD-1 devices dict (or None on failure)
+                         once the query completes. Runs on the reactor thread.
+        """
+        self._write_queue.put_nowait((self._get_td1_data_async_sync, (callback,)))
+
+    def _get_td1_data_async_sync(self, callback: Callable[[Optional[dict]], None]) -> None:
+        """
+        Does the actual GET for TD-1 device data. Called from the background
+        writer thread; schedules callback on the reactor thread.
+
+        :param callback: Called with the TD-1 devices dict (or None on failure)
+        """
+        url = urljoin(self.host, "machine/td1/data")
+        req = Request(url=url)
+        resp = self._get_results(req)
+        devices = resp["devices"] if resp is not None and "devices" in resp else None
+        self.reactor.register_async_callback(lambda et, devices=devices: callback(devices))
 
     def reboot_td1(self, serial_number):
         """

--- a/extras/AFC_utils.py
+++ b/extras/AFC_utils.py
@@ -510,15 +510,29 @@ class AFC_moonraker:
             self.logger.debug("Spoolman server is not defined")
             return None
 
-    def get_file_metadata(self, filename: str) -> dict:
+    def get_file_metadata(self, filename: str, callback: Callable[[Optional[dict]], None]) -> None:
         """
-        Queries moonraker for a print file's metadata.
+        Queues a query for a print file's metadata to run on the background
+        writer thread. Runs asynchronously because the only caller of this
+        (print-start bookkeeping) runs from a reactor timer while printing
+        and can't block on the HTTP round trip to moonraker.
 
-        :param filename: Filename to query moonraker and pull metadata
-        :return dict: Metadata dictionary returned by moonraker, None if the query fails
+        :param filename: Filename to query moonraker and pull metadata for
+        :param callback: Called with the metadata dict (or None on failure)
+                         once the query completes. Runs on the reactor thread.
         """
-        resp: dict = self._get_results(urljoin(self.host, f"{self.FILENAME_PATH}{quote(filename)}"))
-        return resp
+        self._write_queue.put_nowait((self._get_file_metadata_sync, (filename, callback)))
+
+    def _get_file_metadata_sync(self, filename: str, callback: Callable[[Optional[dict]], None]) -> None:
+        """
+        Does the actual GET for a print file's metadata. Called from the
+        background writer thread; schedules callback on the reactor thread.
+
+        :param filename: Filename to query moonraker and pull metadata for
+        :param callback: Called with the metadata dict (or None on failure)
+        """
+        resp: Optional[dict] = self._get_results(urljoin(self.host, f"{self.FILENAME_PATH}{quote(filename)}"))
+        self.reactor.register_async_callback(lambda et, resp=resp: callback(resp))
 
     def get_afc_stats(self) -> Optional[dict]:
         """
@@ -791,18 +805,43 @@ class AFC_PrintFileMetaData:
         :return str: Filename that metadata is currently cached for
         """
         return self._filename
-    @filename.setter
-    def filename(self, value: str) -> None:
+
+    def query_filename(self, value: str, on_ready: Optional[Callable[[], None]] = None) -> None:
         """
-        Sets current filename and queries moonraker for its metadata, caching
-        the result for the `tool_change_count`/`tool_temperatures` properties.
+        Sets current filename and queues a moonraker query for its metadata,
+        caching the result for the `tool_change_count`/`tool_temperatures`
+        properties once it arrives. Runs asynchronously since the only caller
+        of this runs from a reactor timer during printing and can't block on
+        the HTTP round trip.
 
         :param value: Filename to query moonraker and pull metadata for
+        :param on_ready: Called (on the reactor thread) once metadata has been
+                         fetched and cached, or immediately if there's nothing
+                         to fetch
         """
         self._filename = value
         if (self._moonraker
             and value):
-            self._metadata = self._moonraker.get_file_metadata(self._filename) or {}
+            self._moonraker.get_file_metadata(
+                value, lambda resp: self._apply_metadata(value, resp, on_ready))
+        elif on_ready is not None:
+            on_ready()
+
+    def _apply_metadata(self, filename: str, resp: Optional[dict],
+                        on_ready: Optional[Callable[[], None]]) -> None:
+        """
+        Caches a metadata query result, guarding against a stale response
+        landing after filename has since changed again (e.g. the print ended
+        and reset() ran, or a new print started, before this query returned).
+
+        :param filename: Filename this response was fetched for
+        :param resp: Metadata dict returned by moonraker, or None on failure
+        :param on_ready: Called once cached, if provided
+        """
+        if filename == self._filename:
+            self._metadata = resp or {}
+        if on_ready is not None:
+            on_ready()
 
     @property
     def tool_change_count(self) -> int:

--- a/extras/AFC_utils.py
+++ b/extras/AFC_utils.py
@@ -11,6 +11,8 @@ import traceback
 import json
 import inspect
 import re
+import queue
+import threading
 
 from datetime import datetime
 from urllib.request import (
@@ -27,7 +29,7 @@ from urllib.error import (
     HTTPError
 )
 
-from typing import TYPE_CHECKING, Optional, Callable, List
+from typing import TYPE_CHECKING, Optional, Callable, List, Any
 
 if TYPE_CHECKING:
     from extras.AFC_logger import AFC_logger
@@ -393,9 +395,10 @@ class AFC_moonraker:
         AFC logger object to log and print to console
     """
     ERROR_STRING = "Error getting data from moonraker, check AFC.log for more information"
-    def __init__(self, host: str, port: str, logger: AFC_logger):
+    def __init__(self, host: str, port: str, logger: AFC_logger, reactor: Reactor):
         self.port           = port
         self.logger         = logger
+        self.reactor        = reactor
         self.host           = f'{host.rstrip("/")}:{port}'
         self.database_url   = urljoin(self.host, "server/database/item")
         self.afc_stats_key  = "afc_stats"
@@ -404,6 +407,42 @@ class AFC_moonraker:
         self._lane_data     = False
         self.logger.debug(f"Moonraker url: {self.host}")
         self.FILENAME_PATH: str = "server/files/metadata?filename="
+
+        # Fire-and-forget writes (stat updates, lane_data pushes, database
+        # deletes) run on this background thread so a slow/hung moonraker
+        # can't stall the reactor. A single worker keeps them ordered.
+        self._write_queue: queue.Queue = queue.Queue()
+        self._write_thread = threading.Thread(target=self._write_worker, daemon=True)
+        self._write_thread.start()
+
+    def _log_async(self, log_fn: Callable, message: str, **kwargs: Any) -> None:
+        """
+        Schedules a logger call to run on the reactor thread via
+        register_async_callback. AFC_logger touches gcode/webhooks state that
+        isn't safe to call from the background writer thread, and this is also
+        safe to call from the main/reactor thread, so _get_results uses it
+        for every log call regardless of which thread it's running on.
+
+        :param log_fn: Bound AFC_logger method to call (e.g. self.logger.error)
+        :param message: Message to log
+        """
+        self.reactor.register_async_callback(
+            lambda et, log_fn=log_fn, message=message, kwargs=kwargs: log_fn(message, **kwargs))
+
+    def _write_worker(self) -> None:
+        """
+        Background thread loop that drains queued fire-and-forget moonraker
+        requests (stat updates, lane_data pushes, database deletes) in the
+        order they were queued. Runs for the life of the process (daemon
+        thread) so it needs no explicit shutdown.
+        """
+        while True:
+            func, args = self._write_queue.get()
+            try:
+                func(*args)
+            except Exception:
+                self._log_async(self.logger.error, "Unexpected error in moonraker background writer")
+                self._log_async(self.logger.debug, traceback.format_exc())
 
     def _get_results(self, url_string, print_error=True):
         """
@@ -428,10 +467,10 @@ class AFC_moonraker:
             if resp.status >= 200 and resp.status <= 300:
                 data = json.load(resp)
             else:
-                logger(self.ERROR_STRING)
-                logger(f"Response: {resp.status} Reason: {resp.reason}")
+                self._log_async(logger, self.ERROR_STRING)
+                self._log_async(logger, f"Response: {resp.status} Reason: {resp.reason}")
         except:
-            logger(self.ERROR_STRING, traceback=traceback.format_exc())
+            self._log_async(logger, self.ERROR_STRING, traceback=traceback.format_exc())
             data = None
         return data['result'] if data is not None else data
 
@@ -519,7 +558,18 @@ class AFC_moonraker:
 
     def update_afc_stats(self, key, value):
         """
-        Updates afc_stats in moonrakers database with key, value pair
+        Queues an update to afc_stats in moonrakers database with key, value pair.
+        Runs on the background writer thread so the caller isn't blocked.
+
+        :param key: The key indicating the field where the value should be inserted
+        :param value: The value to insert into the database
+        """
+        self._write_queue.put_nowait((self._update_afc_stats_sync, (key, value)))
+
+    def _update_afc_stats_sync(self, key, value) -> None:
+        """
+        Does the actual POST to update afc_stats in moonrakers database.
+        Called from the background writer thread.
 
         :param key: The key indicating the field where the value should be inserted
         :param value: The value to insert into the database
@@ -535,7 +585,8 @@ class AFC_moonraker:
 
         resp = self._get_results(req)
         if resp is None:
-            self.logger.error(f"Error when trying to update {key} in moonraker, see AFC.log for more info")
+            self._log_async(self.logger.error,
+                            f"Error when trying to update {key} in moonraker, see AFC.log for more info")
 
     def get_spool(self, id:int):
         """
@@ -619,9 +670,19 @@ class AFC_moonraker:
 
     def send_lane_data(self, data):
         """
-        Send lane data to moonrakers `machine/set_lane_data` endpoint so that
+        Queues lane data to be sent to moonrakers `machine/set_lane_data` endpoint so that
         other programs can query moonrakers `machine/lane_data` endpoint to see what lanes
-        are loaded and what their colors are.
+        are loaded and what their colors are. Runs on the background writer thread so the
+        caller isn't blocked.
+
+        :params data: Data to send to endpoint
+        """
+        self._write_queue.put_nowait((self._send_lane_data_sync, (data,)))
+
+    def _send_lane_data_sync(self, data) -> None:
+        """
+        Does the actual POST of lane data to moonraker. Called from the
+        background writer thread.
 
         :params data: Data to send to endpoint
         """
@@ -633,15 +694,26 @@ class AFC_moonraker:
             req = Request( url=self.database_url, data=json.dumps(data).encode(),
                         method="POST", headers={"Content-Type": "application/json"})
             if self._get_results(req) is None:
-                self.logger.error("Error sending lane data, check AFC.log for more information")
+                self._log_async(self.logger.error, "Error sending lane data, check AFC.log for more information")
         except HTTPError as e:
-            self.logger.error("Error occurred when trying to send lane data to moonraker database,"+
-                              "\nplease check AFC.log for more information.")
-            self.logger.debug(f"{e}")
+            self._log_async(self.logger.error, "Error occurred when trying to send lane data to moonraker database,"+
+                            "\nplease check AFC.log for more information.")
+            self._log_async(self.logger.debug, f"{e}")
 
     def remove_database_entry(self, namespace, key):
         """
-        Common function for removing entries in moonrakers database
+        Queues removal of an entry in moonrakers database. Runs on the
+        background writer thread so the caller isn't blocked.
+
+        :param namespace: Namespace for moonrakers database
+        :param key: Key to delete from namespace
+        """
+        self._write_queue.put_nowait((self._remove_database_entry_sync, (namespace, key)))
+
+    def _remove_database_entry_sync(self, namespace, key) -> None:
+        """
+        Does the actual DELETE of an entry from moonrakers database. Called
+        from the background writer thread.
 
         :param namespace: Namespace for moonrakers database
         :param key: Key to delete from namespace
@@ -654,16 +726,17 @@ class AFC_moonraker:
             }
             req = Request( self.database_url, urlencode(payload).encode(), method="DELETE")
             urlopen(req)
-            self.logger.debug(f"Removing {key} from {namespace}")
+            self._log_async(self.logger.debug, f"Removing {key} from {namespace}")
         except HTTPError as e:
-            self.logger.debug(
-                f"Error occurred when trying to delete {key} from {namespace} namespace"
-            )
-            self.logger.debug(f"{e}")
+            self._log_async(self.logger.debug,
+                            f"Error occurred when trying to delete {key} from {namespace} namespace")
+            self._log_async(self.logger.debug, f"{e}")
 
     def delete_lane_data(self):
         """
         Function recursively delete's lane_data namespace from moonrakers database.
+        Queries the current keys synchronously (only run once at boot), then queues
+        each removal on the background writer thread via remove_database_entry.
 
         Purpose would be to remove data upon boot just incase someone when from a 8 lane
         system to a 4 lane system, removing and then readding will make sure database has
@@ -672,12 +745,8 @@ class AFC_moonraker:
         resp = self._get_results(urljoin(self.database_url, "?namespace=lane_data"), print_error=False)
         if resp is not None:
             value = resp.get("value")
-            try:
-                for key in value.keys():
-                    self.remove_database_entry("lane_data", key)
-            except HTTPError as e:
-                self.logger.debug("Error occurred when trying to delete lane data")
-                self.logger.debug(f"{e}")
+            for key in value.keys():
+                self.remove_database_entry("lane_data", key)
 
     def trigger_db_backup(self) -> bool:
         """

--- a/extras/AFC_utils.py
+++ b/extras/AFC_utils.py
@@ -397,6 +397,7 @@ class AFC_moonraker:
     """
     ERROR_STRING = "Error getting data from moonraker, check AFC.log for more information"
     REQUEST_TIMEOUT = 10
+    class sentinel: pass
     def __init__(self, host: str, port: str, logger: AFC_logger, reactor: Reactor):
         self.port           = port
         self.logger         = logger
@@ -413,6 +414,7 @@ class AFC_moonraker:
         # Fire-and-forget writes (stat updates, lane_data pushes, database
         # deletes) run on this background thread so a slow/hung moonraker
         # can't stall the reactor. A single worker keeps them ordered.
+        self._write_thread_wait = True
         self._write_queue: Queue = Queue()
         self._write_thread = threading.Thread(target=self._write_worker, daemon=True,
                                               name="afc_moonraker")
@@ -432,6 +434,14 @@ class AFC_moonraker:
         self.reactor.register_async_callback(
             lambda et, log_fn=log_fn, message=message, kwargs=kwargs: log_fn(message, **kwargs))
 
+    def join_thread(self) -> None:
+        """
+        Stops worker thread when klipper:disconnect happens
+        """
+        self._write_queue.put_nowait((self.sentinel, ""))
+        self._write_thread_wait = False
+        self._write_thread.join()
+
     def _write_worker(self) -> None:
         """
         Background thread loop that drains queued fire-and-forget moonraker
@@ -444,8 +454,10 @@ class AFC_moonraker:
             chelper.get_ffi()[1].set_thread_name(thread_name.encode("utf-8"))
         except:
             pass
-        while True:
+        while self._write_thread_wait:
             func, args = self._write_queue.get()
+            if func is self.sentinel:
+                return
             try:
                 func(*args)
             except Exception:

--- a/extras/AFC_utils.py
+++ b/extras/AFC_utils.py
@@ -11,10 +11,11 @@ import traceback
 import json
 import inspect
 import re
-import queue
 import threading
+import chelper
 
 from datetime import datetime
+from queue import Queue
 from urllib.request import (
     Request,
     urlopen
@@ -411,8 +412,9 @@ class AFC_moonraker:
         # Fire-and-forget writes (stat updates, lane_data pushes, database
         # deletes) run on this background thread so a slow/hung moonraker
         # can't stall the reactor. A single worker keeps them ordered.
-        self._write_queue: queue.Queue = queue.Queue()
-        self._write_thread = threading.Thread(target=self._write_worker, daemon=True)
+        self._write_queue: Queue = Queue()
+        self._write_thread = threading.Thread(target=self._write_worker, daemon=True,
+                                              name="afc_moonraker")
         self._write_thread.start()
 
     def _log_async(self, log_fn: Callable, message: str, **kwargs: Any) -> None:
@@ -436,6 +438,11 @@ class AFC_moonraker:
         order they were queued. Runs for the life of the process (daemon
         thread) so it needs no explicit shutdown.
         """
+        try:
+            thread_name = threading.current_thread().name
+            chelper.get_ffi()[1].set_thread_name(thread_name.encode("utf-8"))
+        except:
+            pass
         while True:
             func, args = self._write_queue.get()
             try:

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,10 +1,11 @@
 [mypy]
 files = extras
 
-# stubs/ covers the Klipper classes/methods extras/*.py actually references
-# -- always available, unlike klipper/klippy (an optional, untracked local
-# checkout, not present in CI). Searched in order, so stubs/ takes priority.
-mypy_path=$MYPY_CONFIG_FILE_DIR/stubs:$MYPY_CONFIG_FILE_DIR/klipper/klippy
+# klipper_stubs/ covers the Klipper classes/methods extras/*.py actually
+# references -- always available, unlike klipper/klippy (an optional,
+# untracked local checkout, not present in CI). Searched in order, so
+# klipper_stubs/ takes priority.
+mypy_path=$MYPY_CONFIG_FILE_DIR/klipper_stubs:$MYPY_CONFIG_FILE_DIR/klipper/klippy
 
 # Require full type annotations on every function/method defined in this
 # project's own extras/ modules, and type-check the bodies of any that are
@@ -16,7 +17,7 @@ check_untyped_defs = True
 
 # Klipper's own klippy/extras/ shares the "extras.*" prefix with this
 # project's own extras/ package, and both have __init__.py, so stubbing
-# these under stubs/extras/ would shadow our own modules instead of
+# these under klipper_stubs/extras/ would shadow our own modules instead of
 # coexisting. ignore_missing_imports covers "not found" (no checkout, or a
 # fork checkout missing a fork-specific module); ignore_errors covers
 # "found but under-annotated" so [mypy-extras.*] above doesn't demand

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,11 @@ markers = [
 
 [tool.ruff]
 force-exclude = true  # respect exclude list even when files are passed explicitly (e.g. changed-files in CI)
+# Only lint this project's own code in extras/. `include` scopes bare/recursive
+# scans (e.g. `ruff check .`) to extras/; `exclude` + force-exclude backs that
+# up for explicit file paths (e.g. CI passing a changed-files list), which
+# `include` alone doesn't gate.
+include = ["extras/**/*.py"]
 exclude = [
     # Standard exclusions
     ".bzr", ".direnv", ".eggs", ".git", ".git-rewrite", ".hg", ".ipynb_checkpoints",
@@ -17,11 +22,10 @@ exclude = [
     ".ruff_cache", ".svn", ".tox", ".venv", ".vscode", "__pypackages__",
     "_build", "buck-out", "build", "dist", "node_modules", "site-packages", "venv",
 
-    # Optional: exclude Klipper source tree if just wrapping
-    "klipper",
-
-    # Test files — linting rules don't apply to the test suite
-    "tests",
+    # Everything in this repo other than extras/
+    "community_mods", "config", "coverage-report", "docs", "include",
+    "kalico", "klipper", "klipper_stubs", "templates", "tests",
+    "troubleshooting", "utilities",
 ]
 
 # Same as Black.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -465,8 +465,10 @@ class MockLogger:
     def debug(self, msg, **kwargs):
         self.messages.append(("debug", msg))
 
-    def error(self, msg=None, **kwargs):
-        # AFC_logger.error() can be called as error(msg) or error(message=msg, ...)
+    def error(self, msg=None, traceback=None, stack_name="", **kwargs):
+        # Real AFC_logger.error() signature is (message, traceback=None, stack_name=""),
+        # accepting traceback/stack_name positionally or by keyword -- match that here
+        # so tests hitting either calling convention don't get a spurious TypeError.
         message = msg if msg is not None else kwargs.get("message", "")
         self.messages.append(("error", message))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -299,6 +299,9 @@ class MockReactor:
     def register_callback(self, callback, waketime=None):
         pass
 
+    def register_async_callback(self, callback, waketime=None):
+        pass
+
     def unregister_timer(self, timer):
         pass
 

--- a/tests/test_AFC.py
+++ b/tests/test_AFC.py
@@ -127,6 +127,8 @@ def _make_afc():
     obj.logger = MockLogger()
     obj.reactor = inner.reactor
     obj.moonraker = None
+    obj._var_write_thread_wait = True
+    obj._var_write_thread = MagicMock()
     obj.function = MagicMock()
     obj.gcode = MagicMock()
     obj.message_queue = []
@@ -4729,3 +4731,83 @@ class TestVarWriteWorker:
                 obj._var_write_worker()
 
         obj._write_vars_snapshot.assert_called_once_with({"a": 1})
+
+    def test_returns_on_sentinel_without_processing_it(self):
+        """join_threads queues the sentinel to stop the loop; the worker must
+        return instead of treating it as a snapshot to write."""
+        obj = _make_afc()
+        obj._var_write_queue = MagicMock()
+        obj._var_write_queue.get.side_effect = [obj.sentinel]
+        obj._write_vars_snapshot = MagicMock()
+
+        result = obj._var_write_worker()
+
+        assert result is None
+        obj._write_vars_snapshot.assert_not_called()
+
+    def test_stops_looping_once_join_threads_clears_wait_flag(self):
+        """Simulates a real klippy:disconnect: join_threads flips the wait
+        flag and queues the sentinel, and the worker must exit its loop."""
+        obj = _make_afc()
+        obj._var_write_queue = MagicMock()
+        obj._var_write_queue.get.side_effect = [{"a": 1}]
+        obj._write_vars_snapshot = MagicMock()
+        obj.moonraker = None
+
+        def stop_after_snapshot(data):
+            obj.join_threads()
+
+        obj._write_vars_snapshot.side_effect = stop_after_snapshot
+
+        obj._var_write_worker()
+
+        obj._write_vars_snapshot.assert_called_once_with({"a": 1})
+        assert obj._var_write_thread_wait is False
+
+
+class TestJoinThreads:
+    """join_threads runs on klippy:disconnect to stop the background var
+    writer thread and, if moonraker was set up, its writer thread too."""
+
+    def _make_afc_for_join_threads(self):
+        obj = _make_afc()
+        obj._var_write_thread_wait = True
+        obj._var_write_queue = MagicMock()
+        return obj
+
+    def test_clears_var_write_thread_wait_flag(self):
+        obj = self._make_afc_for_join_threads()
+        obj.join_threads()
+        assert obj._var_write_thread_wait is False
+
+    def test_puts_sentinel_on_var_write_queue(self):
+        obj = self._make_afc_for_join_threads()
+        obj.join_threads()
+        obj._var_write_queue.put_nowait.assert_called_once_with(obj.sentinel)
+
+    def test_calls_moonraker_join_thread_when_moonraker_present(self):
+        obj = self._make_afc_for_join_threads()
+        obj.moonraker = MagicMock()
+        obj.join_threads()
+        obj.moonraker.join_thread.assert_called_once()
+
+    def test_does_not_error_when_moonraker_is_none(self):
+        obj = self._make_afc_for_join_threads()
+        obj.moonraker = None
+        obj.join_threads()  # must not raise
+
+    def test_joins_var_write_thread(self):
+        obj = self._make_afc_for_join_threads()
+        obj.join_threads()
+        obj._var_write_thread.join.assert_called_once()
+
+    def test_joins_var_write_thread_after_queuing_sentinel(self):
+        """The worker only breaks out of its loop once it dequeues the
+        sentinel, so the sentinel must be queued before join() is called or
+        this would deadlock against a real thread."""
+        obj = self._make_afc_for_join_threads()
+        order = []
+        obj._var_write_queue.put_nowait.side_effect = lambda *a: order.append("put_nowait")
+        obj._var_write_thread.join.side_effect = lambda *a, **kw: order.append("join")
+        obj.join_threads()
+        assert order == ["put_nowait", "join"]

--- a/tests/test_AFC.py
+++ b/tests/test_AFC.py
@@ -24,6 +24,7 @@ Covers:
 from __future__ import annotations
 
 import json
+import threading
 from unittest.mock import MagicMock, call, patch
 import pytest
 
@@ -4699,5 +4700,32 @@ class TestVarWriteWorker:
 
         with pytest.raises(RuntimeError, match="stop test loop"):
             obj._var_write_worker()
+
+        obj._write_vars_snapshot.assert_called_once_with({"a": 1})
+
+    def test_sets_os_thread_name(self):
+        obj = _make_afc()
+        obj._var_write_queue = MagicMock()
+        obj._var_write_queue.get.side_effect = [RuntimeError("stop test loop")]
+        fake_ffi_lib = MagicMock()
+
+        with patch("chelper.get_ffi", return_value=(MagicMock(), fake_ffi_lib)):
+            with pytest.raises(RuntimeError, match="stop test loop"):
+                obj._var_write_worker()
+
+        fake_ffi_lib.set_thread_name.assert_called_once_with(
+            threading.current_thread().name.encode("utf-8"))
+
+    def test_survives_exception_setting_thread_name(self):
+        """A failure naming the OS thread (e.g. chelper unavailable) must not
+        stop the worker from processing queued snapshots."""
+        obj = _make_afc()
+        obj._var_write_queue = MagicMock()
+        obj._var_write_queue.get.side_effect = [{"a": 1}, RuntimeError("stop test loop")]
+        obj._write_vars_snapshot = MagicMock()
+
+        with patch("chelper.get_ffi", side_effect=Exception("boom")):
+            with pytest.raises(RuntimeError, match="stop test loop"):
+                obj._var_write_worker()
 
         obj._write_vars_snapshot.assert_called_once_with({"a": 1})

--- a/tests/test_AFC.py
+++ b/tests/test_AFC.py
@@ -3237,27 +3237,27 @@ class TestInPrintReactorTimer:
     def test_calls_moonraker_when_in_print_and_moonraker_set(self):
         """Happy path: print_data_metadata is queried (async) when both
         in_print and moonraker are set; applying the result is deferred to
-        the on_ready callback, simulated here firing immediately."""
+        the on_fetched callback, simulated here firing immediately."""
         obj = self._make()
         obj.moonraker = MagicMock()
         obj.print_data_metadata = MagicMock()
         obj.print_data_metadata.tool_change_count = 7
         obj.print_data_metadata.tool_temperatures = [210]
         obj.print_data_metadata.query_filename.side_effect = (
-            lambda value, on_ready=None: on_ready() if on_ready else None
+            lambda value, on_fetched=None: on_fetched() if on_fetched else None
         )
         obj.function.in_print.return_value = (True, "test.gcode")
         obj.function.get_current_lane_obj.return_value = None
         obj.in_print_reactor_timer(0.0)
         obj.print_data_metadata.query_filename.assert_called_once_with(
-            "test.gcode", on_ready=obj._finish_print_start)
+            "test.gcode", on_fetched=obj._finish_print_start)
         assert obj.number_of_toolchanges == 7
         assert obj.print_tool_temperatures == [210]
         assert obj.current_toolchange == -1
 
-    def test_toolchange_count_not_applied_until_on_ready_fires(self):
+    def test_toolchange_count_not_applied_until_on_fetched_fires(self):
         """The metadata fetch is async: number_of_toolchanges must stay at
-        its reset-to-0 value until the on_ready callback actually runs, not
+        its reset-to-0 value until the on_fetched callback actually runs, not
         just because query_filename() was called."""
         obj = self._make()
         obj.moonraker = MagicMock()
@@ -3265,7 +3265,7 @@ class TestInPrintReactorTimer:
         obj.print_data_metadata.tool_change_count = 7
         captured = {}
         obj.print_data_metadata.query_filename.side_effect = (
-            lambda value, on_ready=None: captured.setdefault("on_ready", on_ready)
+            lambda value, on_fetched=None: captured.setdefault("on_fetched", on_fetched)
         )
         obj.function.in_print.return_value = (True, "test.gcode")
         obj.function.get_current_lane_obj.return_value = None
@@ -3274,7 +3274,7 @@ class TestInPrintReactorTimer:
         assert obj.number_of_toolchanges == 0
         assert obj.current_toolchange != -1
 
-        captured["on_ready"]()
+        captured["on_fetched"]()
         assert obj.number_of_toolchanges == 7
         assert obj.current_toolchange == -1
 

--- a/tests/test_AFC.py
+++ b/tests/test_AFC.py
@@ -3235,18 +3235,47 @@ class TestInPrintReactorTimer:
         assert result == obj.reactor.NEVER
 
     def test_calls_moonraker_when_in_print_and_moonraker_set(self):
-        """Happy path: print_data_metadata is queried when both in_print and moonraker are set."""
+        """Happy path: print_data_metadata is queried (async) when both
+        in_print and moonraker are set; applying the result is deferred to
+        the on_ready callback, simulated here firing immediately."""
         obj = self._make()
         obj.moonraker = MagicMock()
         obj.print_data_metadata = MagicMock()
         obj.print_data_metadata.tool_change_count = 7
         obj.print_data_metadata.tool_temperatures = [210]
+        obj.print_data_metadata.query_filename.side_effect = (
+            lambda value, on_ready=None: on_ready() if on_ready else None
+        )
         obj.function.in_print.return_value = (True, "test.gcode")
         obj.function.get_current_lane_obj.return_value = None
         obj.in_print_reactor_timer(0.0)
-        assert obj.print_data_metadata.filename == "test.gcode"
+        obj.print_data_metadata.query_filename.assert_called_once_with(
+            "test.gcode", on_ready=obj._finish_print_start)
         assert obj.number_of_toolchanges == 7
         assert obj.print_tool_temperatures == [210]
+        assert obj.current_toolchange == -1
+
+    def test_toolchange_count_not_applied_until_on_ready_fires(self):
+        """The metadata fetch is async: number_of_toolchanges must stay at
+        its reset-to-0 value until the on_ready callback actually runs, not
+        just because query_filename() was called."""
+        obj = self._make()
+        obj.moonraker = MagicMock()
+        obj.print_data_metadata = MagicMock()
+        obj.print_data_metadata.tool_change_count = 7
+        captured = {}
+        obj.print_data_metadata.query_filename.side_effect = (
+            lambda value, on_ready=None: captured.setdefault("on_ready", on_ready)
+        )
+        obj.function.in_print.return_value = (True, "test.gcode")
+        obj.function.get_current_lane_obj.return_value = None
+
+        obj.in_print_reactor_timer(0.0)
+        assert obj.number_of_toolchanges == 0
+        assert obj.current_toolchange != -1
+
+        captured["on_ready"]()
+        assert obj.number_of_toolchanges == 7
         assert obj.current_toolchange == -1
 
     def test_does_not_call_moonraker_when_not_in_print(self):
@@ -3258,6 +3287,20 @@ class TestInPrintReactorTimer:
         obj.in_print_reactor_timer(0.0)
         assert not obj.print_data_metadata.method_calls
         assert obj.number_of_toolchanges == 0
+
+    def test_finish_print_start_skips_buffer_update_when_lane_has_no_buffer(self):
+        """Covers current_lane truthy but buffer_obj falsy in _finish_print_start."""
+        obj = self._make()
+        obj.moonraker = None
+        current_lane = MagicMock()
+        current_lane.buffer_obj = None
+        obj.function.get_current_lane_obj.return_value = current_lane
+        obj.function.in_print.return_value = (True, "test.gcode")
+
+        # Would raise AttributeError from None.update_filament_error_pos() if
+        # the buffer_obj-is-None guard were missing
+        obj.in_print_reactor_timer(0.0)
+        assert obj.current_toolchange == -1
 
     def test_skips_metadata_lookup_when_print_data_metadata_is_none(self):
         """Covers the `self.print_data_metadata` half of

--- a/tests/test_AFC.py
+++ b/tests/test_AFC.py
@@ -23,7 +23,8 @@ Covers:
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, call
+import json
+from unittest.mock import MagicMock, call, patch
 import pytest
 
 from extras.AFC import afc, State, AFC_VERSION
@@ -4531,3 +4532,129 @@ class TestLaneUnload:
             side_effect=lambda _lane: seen.append(obj.current_state))
         obj.LANE_UNLOAD(cur_lane)
         assert seen == [State.EJECTING_LANE]
+
+
+# ── save_vars / background var-file writer ─────────────────────────────────────
+
+def _make_afc_for_save_vars(prep_done=True):
+    """Build an afc instance wired up for save_vars(), with the write queue
+    mocked so tests can inspect what gets enqueued without touching disk."""
+    obj = _make_afc()
+    obj.VarFile = "/tmp/AFC_test_var"
+    obj.prep_done = prep_done
+    obj.function.get_current_lane = MagicMock(return_value="lane1")
+    obj._var_write_queue = MagicMock()
+
+    lane = MagicMock()
+    lane.name = "lane1"
+    lane.get_status.return_value = {"map": ["T0"]}
+    unit = MagicMock()
+    unit.name = "Turtle_1"
+    unit.lanes = {"lane1": lane}
+    obj.units = {"Turtle_1": unit}
+    obj.lanes = {"lane1": lane}
+
+    extruder = MagicMock()
+    extruder.name = "extruder"
+    extruder.lane_loaded = "lane1"
+    obj.tools = {"extruder": extruder}
+    obj.get_bypass_state = MagicMock(return_value=False)
+    return obj
+
+
+class TestSaveVars:
+    def test_returns_early_when_prep_not_done(self):
+        obj = _make_afc_for_save_vars(prep_done=False)
+        obj.save_vars()
+        obj._var_write_queue.put_nowait.assert_not_called()
+
+    def test_enqueues_snapshot_when_prep_done(self):
+        obj = _make_afc_for_save_vars(prep_done=True)
+        obj.save_vars()
+        obj._var_write_queue.put_nowait.assert_called_once()
+
+    def test_enqueued_snapshot_has_expected_lane_and_system_data(self):
+        obj = _make_afc_for_save_vars(prep_done=True)
+        obj.save_vars()
+        data = obj._var_write_queue.put_nowait.call_args[0][0]
+        assert data["Turtle_1"]["lane1"] == {"map": ["T0"]}
+        assert data["system"]["current_load"] == "lane1"
+        assert data["system"]["num_units"] == 1
+        assert data["system"]["num_lanes"] == 1
+        assert data["system"]["num_extruders"] == 1
+        assert data["system"]["bypass"] == {"enabled": False}
+        assert data["system"]["extruders"]["extruder"]["lane_loaded"] == "lane1"
+
+    def test_does_not_touch_disk_directly(self):
+        """The actual write must happen on the background thread, not inline."""
+        obj = _make_afc_for_save_vars(prep_done=True)
+        with patch("builtins.open") as mock_open:
+            obj.save_vars()
+        mock_open.assert_not_called()
+
+
+class TestWriteVarsSnapshot:
+    def test_writes_json_to_var_file(self, tmp_path):
+        obj = _make_afc()
+        obj.VarFile = str(tmp_path / "AFC")
+        obj._write_vars_snapshot({"system": {"current_load": "lane1"}})
+        written = (tmp_path / "AFC.unit").read_text()
+        assert json.loads(written) == {"system": {"current_load": "lane1"}}
+
+    def test_write_failure_schedules_error_log_on_reactor(self):
+        obj = _make_afc()
+        obj.VarFile = "/nonexistent_dir_for_afc_tests/does/not/exist/AFC"
+        obj.reactor.register_async_callback = MagicMock()
+
+        obj._write_vars_snapshot({"a": 1})
+
+        obj.reactor.register_async_callback.assert_called_once()
+
+    def test_scheduled_callback_logs_via_log_save_vars_error(self):
+        """The callable handed to register_async_callback, once invoked with
+        an eventtime (as the reactor would), must call _log_save_vars_error
+        with a formatted error string."""
+        obj = _make_afc()
+        obj.VarFile = "/nonexistent_dir_for_afc_tests/does/not/exist/AFC"
+        obj.reactor.register_async_callback = MagicMock()
+        obj._log_save_vars_error = MagicMock()
+
+        obj._write_vars_snapshot({"a": 1})
+
+        scheduled_cb = obj.reactor.register_async_callback.call_args[0][0]
+        scheduled_cb(0.0)
+        obj._log_save_vars_error.assert_called_once()
+        err_arg = obj._log_save_vars_error.call_args[0][0]
+        assert err_arg.startswith("Error:")
+
+    def test_success_does_not_schedule_error_log(self):
+        obj = _make_afc()
+        obj.VarFile = "/tmp/AFC_test_var_success"
+        obj.reactor.register_async_callback = MagicMock()
+        obj._write_vars_snapshot({"a": 1})
+        obj.reactor.register_async_callback.assert_not_called()
+
+
+class TestLogSaveVarsError:
+    def test_logs_expected_error_and_debug_messages(self):
+        obj = _make_afc()
+        obj._log_save_vars_error("Error:boom\ntraceback here")
+        assert obj.logger.messages == [
+            ("error", "Error happened when trying to save variables, check AFC.log for error"),
+            ("debug", "Error:boom\ntraceback here"),
+        ]
+
+
+class TestVarWriteWorker:
+    def test_processes_queued_snapshot_then_loops(self):
+        """Drives exactly one loop iteration: the second queue.get() raises
+        to break out of the otherwise-infinite loop deterministically."""
+        obj = _make_afc()
+        obj._var_write_queue = MagicMock()
+        obj._var_write_queue.get.side_effect = [{"a": 1}, RuntimeError("stop test loop")]
+        obj._write_vars_snapshot = MagicMock()
+
+        with pytest.raises(RuntimeError, match="stop test loop"):
+            obj._var_write_worker()
+
+        obj._write_vars_snapshot.assert_called_once_with({"a": 1})

--- a/tests/test_AFC_functions.py
+++ b/tests/test_AFC_functions.py
@@ -1889,3 +1889,107 @@ class TestHandleActivateExtruder:
         active_lane.do_enable.assert_called_once_with(True)
         active_lane.unit_obj.lane_not_ready.assert_not_called()
         active_lane.unit_obj.lane_loaded.assert_not_called()
+
+
+# ── check_for_td1_error / _check_td1_error_in_data ────────────────────────────
+
+class TestCheckForTd1Error:
+    def test_delegates_to_moonraker_fetch_then_checks_data(self):
+        func = _make_func()
+        func.afc.moonraker = MagicMock()
+        func.afc.moonraker.get_td1_data.return_value = {"SN1": {"error": None}}
+        error_occurred, msg = func.check_for_td1_error()
+        func.afc.moonraker.get_td1_data.assert_called_once_with()
+        assert error_occurred is False
+        assert msg == ""
+
+
+class TestCheckTd1ErrorInData:
+    def test_none_data_reports_no_error(self):
+        """Covers td1_data being None (a failed fetch) without crashing."""
+        func = _make_func()
+        error_occurred, msg = func._check_td1_error_in_data(None)
+        assert error_occurred is False
+        assert msg == ""
+
+    def test_no_devices_have_errors(self):
+        func = _make_func()
+        td1_data = {"SN1": {"error": None}, "SN2": {"error": None}}
+        error_occurred, msg = func._check_td1_error_in_data(td1_data)
+        assert error_occurred is False
+        assert msg == ""
+
+    def test_matching_serial_with_error_reports_it(self):
+        func = _make_func()
+        td1_data = {"SN1": {"error": "jam"}}
+        error_occurred, msg = func._check_td1_error_in_data(td1_data, serial_number="SN1")
+        assert error_occurred is True
+        assert "SN1" in msg
+        assert "jam" in msg
+
+    def test_non_matching_serial_number_ignores_other_devices_error(self):
+        """A specific serial_number filters out errors on other devices."""
+        func = _make_func()
+        td1_data = {"SN1": {"error": "jam"}}
+        error_occurred, msg = func._check_td1_error_in_data(td1_data, serial_number="SN2")
+        assert error_occurred is False
+        assert msg == ""
+
+    def test_serial_number_none_checks_all_devices(self):
+        func = _make_func()
+        td1_data = {"SN1": {"error": None}, "SN2": {"error": "overheating"}}
+        error_occurred, msg = func._check_td1_error_in_data(td1_data, serial_number=None)
+        assert error_occurred is True
+        assert "SN2" in msg
+
+    def test_print_error_true_logs_error(self):
+        func = _make_func()
+        td1_data = {"SN1": {"error": "jam"}}
+        func._check_td1_error_in_data(td1_data, serial_number="SN1", print_error=True)
+        errors = [m for lvl, m in func.logger.messages if lvl == "error"]
+        assert len(errors) == 1
+
+    def test_print_error_false_does_not_log(self):
+        func = _make_func()
+        td1_data = {"SN1": {"error": "jam"}}
+        func._check_td1_error_in_data(td1_data, serial_number="SN1", print_error=False)
+        errors = [m for lvl, m in func.logger.messages if lvl == "error"]
+        assert len(errors) == 0
+
+
+# ── check_for_td1_id / _check_td1_id_in_data ──────────────────────────────────
+
+class TestCheckForTd1Id:
+    def test_delegates_to_moonraker_fetch_then_checks_data(self):
+        func = _make_func()
+        func.afc.moonraker = MagicMock()
+        func.afc.moonraker.get_td1_data.return_value = {"SN1": {"error": None}}
+        valid, msg = func.check_for_td1_id("SN1")
+        func.afc.moonraker.get_td1_data.assert_called_once_with()
+        assert valid is True
+
+
+class TestCheckTd1IdInData:
+    def test_none_data_reports_not_found(self):
+        """Covers td1_data being None (a failed fetch) without crashing."""
+        func = _make_func()
+        valid, msg = func._check_td1_id_in_data(None, "SN1")
+        assert valid is False
+        assert "SN1" in msg
+
+    def test_serial_not_in_data_reports_not_found(self):
+        func = _make_func()
+        valid, msg = func._check_td1_id_in_data({"SN2": {"error": None}}, "SN1")
+        assert valid is False
+        assert "SN1" in msg
+
+    def test_serial_present_with_no_error_is_valid(self):
+        func = _make_func()
+        valid, msg = func._check_td1_id_in_data({"SN1": {"error": None}}, "SN1")
+        assert valid is True
+
+    def test_serial_present_with_error_is_not_valid(self):
+        func = _make_func()
+        valid, msg = func._check_td1_id_in_data({"SN1": {"error": "jam"}}, "SN1")
+        assert valid is False
+        assert "jam" in msg

--- a/tests/test_AFC_functions.py
+++ b/tests/test_AFC_functions.py
@@ -1946,15 +1946,18 @@ class TestCheckTd1ErrorInData:
         func = _make_func()
         td1_data = {"SN1": {"error": "jam"}}
         func._check_td1_error_in_data(td1_data, serial_number="SN1", print_error=True)
-        errors = [m for lvl, m in func.logger.messages if lvl == "error"]
-        assert len(errors) == 1
+        assert func.logger.messages == [
+            ("error",
+             "Error with TD-1 Serial: SN1, please fix error with TD-1 and run 'AFC_RESET_TD1 SERIAL=SN1' macro.\n"
+             "Some errors can occur when first booting machine and filament is in TD-1 device\n"
+             "Reported Error: jam"),
+        ]
 
     def test_print_error_false_does_not_log(self):
         func = _make_func()
         td1_data = {"SN1": {"error": "jam"}}
         func._check_td1_error_in_data(td1_data, serial_number="SN1", print_error=False)
-        errors = [m for lvl, m in func.logger.messages if lvl == "error"]
-        assert len(errors) == 0
+        assert func.logger.messages == []
 
 
 # ── check_for_td1_id / _check_td1_id_in_data ──────────────────────────────────

--- a/tests/test_AFC_lane.py
+++ b/tests/test_AFC_lane.py
@@ -3918,8 +3918,25 @@ class TestPrepCallback:
         lane.afc.TOOL_LOAD.return_value = True
         lane.prep_callback(10, True)
         lane.afc.TOOL_LOAD.assert_called_once_with(lane)
-        lane.afc.spool._set_values.assert_called_once_with(lane)
+        assert lane.afc.spool._set_values.call_args.args == (lane,)
         lane.afc.afc_stats.increase_load_error_count.assert_not_called()
+
+    def test_direct_load_hub_defers_active_spool_push_to_set_values_on_done(self):
+        """TOOL_LOAD may push the active spool to Spoolman using a stale
+        spool_id before _set_values resolves a pending next_spool_id (e.g.
+        from an NFC scan). The on_done callback passed to _set_values must
+        re-push using the settled spool_id, and must not fire eagerly."""
+        lane = _make_lane_ready_to_load()
+        lane.hub = "direct_load"
+        lane.afc.TOOL_LOAD.return_value = True
+        lane.prep_callback(10, True)
+
+        lane.afc.spool.set_active_spool.assert_not_called()
+
+        on_done = lane.afc.spool._set_values.call_args.kwargs["on_done"]
+        lane.spool_id = 99
+        on_done()
+        lane.afc.spool.set_active_spool.assert_called_once_with(99)
 
     def test_direct_load_hub_tool_load_failure_increases_load_error_count(self):
         """When TOOL_LOAD fails in the direct_load prep_callback branch, the

--- a/tests/test_AFC_lane.py
+++ b/tests/test_AFC_lane.py
@@ -546,6 +546,81 @@ class TestGetTd1DataUnitHook:
         assert "not loaded" in msg.lower()
 
 
+# ── get_td1_data_load / _apply_td1_data_load ──────────────────────────────────
+# Runs at the end of every TOOL_LOAD, so this fetches asynchronously (unlike
+# get_td1_data above, used by calibration/PREP capture, which stays synchronous).
+
+class TestGetTd1DataLoad:
+    def _make(self, td1_present=True, td1_device_id="SN1"):
+        lane = _make_afc_lane()
+        lane.afc.td1_present = td1_present
+        lane.td1_device_id = td1_device_id
+        lane.afc.moonraker = MagicMock()
+        return lane
+
+    def test_td1_not_present_skips_entirely(self):
+        lane = self._make(td1_present=False)
+        lane.get_td1_data_load()
+        lane.afc.moonraker.get_td1_data_async.assert_not_called()
+
+    def test_no_device_id_skips_entirely(self):
+        lane = self._make(td1_device_id=None)
+        lane.get_td1_data_load()
+        lane.afc.moonraker.get_td1_data_async.assert_not_called()
+
+    def test_no_moonraker_skips_entirely(self):
+        lane = self._make()
+        lane.afc.moonraker = None
+        lane.get_td1_data_load()  # must not raise
+
+    def test_dispatches_async_fetch_with_apply_callback(self):
+        lane = self._make()
+        lane.get_td1_data_load()
+        lane.afc.moonraker.get_td1_data_async.assert_called_once_with(
+            lane._apply_td1_data_load)
+
+
+class TestApplyTd1DataLoad:
+    def _make(self, td1_device_id="SN1"):
+        lane = _make_afc_lane()
+        lane.td1_device_id = td1_device_id
+        lane.unit_obj = MagicMock()
+        return lane
+
+    def test_invalid_device_skips_apply(self):
+        lane = self._make()
+        lane.afc.function._check_td1_id_in_data.return_value = (False, "not found")
+
+        lane._apply_td1_data_load({"OTHER": {}})
+
+        lane.afc.function._check_td1_id_in_data.assert_called_once_with({"OTHER": {}}, "SN1")
+        lane.unit_obj._apply_td1_data.assert_not_called()
+
+    def test_valid_device_applies_with_ignore_time(self):
+        lane = self._make()
+        lane.afc.function._check_td1_id_in_data.return_value = (True, "")
+        devices = {"SN1": {"td": "PLA", "color": "#FF0000", "scan_time": "2024-01-01T12:00:00Z"}}
+
+        lane._apply_td1_data_load(devices)
+
+        args = lane.unit_obj._apply_td1_data.call_args[0]
+        assert args[0] is lane
+        assert args[2] == devices
+        kwargs = lane.unit_obj._apply_td1_data.call_args[1]
+        assert kwargs.get("ignore_time") is True
+
+    def test_none_devices_from_failed_fetch_is_treated_as_invalid(self):
+        """A failed async fetch delivers None; _check_td1_id_in_data already
+        handles that (device can't be found in no data), so apply is skipped."""
+        lane = self._make()
+        lane.afc.function._check_td1_id_in_data.return_value = (False, "not found")
+
+        lane._apply_td1_data_load(None)
+
+        lane.afc.function._check_td1_id_in_data.assert_called_once_with(None, "SN1")
+        lane.unit_obj._apply_td1_data.assert_not_called()
+
+
 # ── handle_load_runout ────────────────────────────────────────────────────────
 
 class TestHandleLoadRunout:

--- a/tests/test_AFC_spool.py
+++ b/tests/test_AFC_spool.py
@@ -1464,7 +1464,7 @@ class TestSetValues:
         spool.next_spool_id = 42
         spool.set_spoolID = MagicMock()
         spool._set_values(lane)
-        spool.set_spoolID.assert_called_once_with(lane, 42)
+        spool.set_spoolID.assert_called_once_with(lane, 42, on_done=None)
         assert spool.next_spool_id is None  # consumed after use
 
     def test_set_value_material_not_set_remember_spool(self):
@@ -1506,6 +1506,40 @@ class TestSetValues:
         spool._set_values(lane)
         assert lane.material == ""
         assert lane.weight == 0
+
+    def test_on_done_forwarded_to_set_spool_id_when_next_spool_id_set(self):
+        spool = _make_spool()
+        lane = _make_lane()
+        lane.remember_spool = False
+        spool.afc.spoolman = MagicMock()
+        spool.next_spool_id = 42
+        spool.set_spoolID = MagicMock()
+        on_done = MagicMock()
+        spool._set_values(lane, on_done=on_done)
+        spool.set_spoolID.assert_called_once_with(lane, 42, on_done=on_done)
+        on_done.assert_not_called()  # only set_spoolID's async fetch may call it
+
+    def test_on_done_called_immediately_when_no_pending_spool_id(self):
+        spool = _make_spool()
+        lane = _make_lane()
+        lane.remember_spool = False
+        spool.afc.spoolman = MagicMock()
+        spool.next_spool_id = None
+        spool.set_spoolID = MagicMock()
+        on_done = MagicMock()
+        spool._set_values(lane, on_done=on_done)
+        spool.set_spoolID.assert_not_called()
+        on_done.assert_called_once()
+
+    def test_on_done_not_required(self):
+        """Existing callers that don't pass on_done keep working unchanged."""
+        spool = _make_spool()
+        lane = _make_lane()
+        lane.remember_spool = False
+        spool.afc.spoolman = MagicMock()
+        spool.next_spool_id = None
+        spool.set_spoolID = MagicMock()
+        spool._set_values(lane)  # must not raise
 
 
 # ── set_spoolID ───────────────────────────────────────────────────────────────

--- a/tests/test_AFC_spool.py
+++ b/tests/test_AFC_spool.py
@@ -1489,6 +1489,13 @@ def _make_spool_result(material="PLA", color_hex="FF0000", weight=800.0):
     }
 
 
+def _stub_get_spool(spool, result):
+    """Makes afc.moonraker.get_spool(id, callback) invoke callback
+    immediately (as if the async fetch completed inline) with `result`."""
+    spool.afc.moonraker.get_spool = MagicMock(
+        side_effect=lambda id, callback: callback(result))
+
+
 class TestSetSpoolID:
     def _make_spool_with_spoolman(self):
         spool = _make_spool()
@@ -1533,7 +1540,7 @@ class TestSetSpoolID:
         lane.remember_spool = False
         lane.espooler = MagicMock()
         result = _make_spool_result()
-        spool.afc.moonraker.get_spool = MagicMock(return_value=result)
+        _stub_get_spool(spool, result)
         spool.set_spoolID(lane, 42)
         assert lane.spool_id == 42
         assert lane.material == "PLA"
@@ -1551,7 +1558,7 @@ class TestSetSpoolID:
         result = _make_spool_result()
         result["filament"]["vendor"] = {}
         result["filament"]["vendor"]["name"] = "Polymaker"
-        spool.afc.moonraker.get_spool = MagicMock(return_value=result)
+        _stub_get_spool(spool, result)
         spool.set_spoolID(lane, 42)
         assert lane.spool_id == 42
         assert lane.material == "PLA"
@@ -1559,7 +1566,7 @@ class TestSetSpoolID:
         assert lane.spool_vendor == "Polymaker"
         spool.set_snapmaker_filament_params.assert_called_once()
         spool.afc.function.afc_led.assert_not_called()
-    
+
     def test_valid_spool_id_lane_not_loaded_lane_in_unit(self):
         spool = self._make_spool_with_spoolman()
         lane = _make_lane()
@@ -1569,7 +1576,7 @@ class TestSetSpoolID:
         lane.unit = "test"
         spool.afc.units[lane.unit] = lane.unit_obj
         result = _make_spool_result()
-        spool.afc.moonraker.get_spool = MagicMock(return_value=result)
+        _stub_get_spool(spool, result)
         spool.set_spoolID(lane, 42)
         spool.afc.function.afc_led.assert_not_called()
 
@@ -1582,10 +1589,10 @@ class TestSetSpoolID:
         lane.remember_spool = False
         lane.espooler = MagicMock()
         result = _make_spool_result()
-        spool.afc.moonraker.get_spool = MagicMock(return_value=result)
+        _stub_get_spool(spool, result)
         spool.set_spoolID(lane, 42)
         lane.unit_obj.lane_loaded.assert_called_once_with(lane, force=True)
-    
+
     def test_valid_spool_id_lane_loaded_lane_not_in_unit(self):
         spool = self._make_spool_with_spoolman()
         lane = _make_lane()
@@ -1594,7 +1601,7 @@ class TestSetSpoolID:
         lane.remember_spool = False
         lane.espooler = MagicMock()
         result = _make_spool_result()
-        spool.afc.moonraker.get_spool = MagicMock(return_value=result)
+        _stub_get_spool(spool, result)
         spool.set_spoolID(lane, 42)
         spool.afc.function.afc_led.assert_not_called()
 
@@ -1604,7 +1611,7 @@ class TestSetSpoolID:
         lane.remember_spool = False
         lane.espooler = MagicMock()
         result = _make_spool_result(weight=0.0)
-        spool.afc.moonraker.get_spool = MagicMock(return_value=result)
+        _stub_get_spool(spool, result)
         spool.disable_weight_check = False
         spool.clear_values = MagicMock()
         spool.set_spoolID(lane, 42)
@@ -1617,7 +1624,7 @@ class TestSetSpoolID:
         lane.remember_spool = False
         lane.espooler = MagicMock()
         result = _make_spool_result(weight=0.0)
-        spool.afc.moonraker.get_spool = MagicMock(return_value=result)
+        _stub_get_spool(spool, result)
         spool.disable_weight_check = True
         spool.set_spoolID(lane, 42)
         spool.afc.error.AFC_error.assert_not_called()
@@ -1629,7 +1636,7 @@ class TestSetSpoolID:
         lane.espooler = MagicMock()
         result = _make_spool_result()
         result["filament"]["multi_color_hexes"] = "AABBCC,001122,334455"
-        spool.afc.moonraker.get_spool = MagicMock(return_value=result)
+        _stub_get_spool(spool, result)
         spool.set_spoolID(lane, 42)
         assert lane.color == "#AABBCC"
         assert lane.multi_color == result["filament"]["multi_color_hexes"].split(",")
@@ -1641,7 +1648,7 @@ class TestSetSpoolID:
         lane.espooler = MagicMock()
         result = _make_spool_result(color_hex="AABBCC")
         result["filament"]["multi_color_hexes"] = None
-        spool.afc.moonraker.get_spool = MagicMock(return_value=result)
+        _stub_get_spool(spool, result)
         spool.set_spoolID(lane, 42)
         assert lane.color == "#AABBCC"
         assert lane.multi_color == []
@@ -1654,21 +1661,82 @@ class TestSetSpoolID:
         lane.extruder_temp = None  # explicitly set before call
         lane.espooler = MagicMock()
         result = _make_spool_result()
-        spool.afc.moonraker.get_spool = MagicMock(return_value=result)
+        _stub_get_spool(spool, result)
         spool.set_spoolID(lane, 42)
         # extruder_temp should NOT be overwritten when the flag is True
         assert lane.extruder_temp is None
 
-    def test_exception_in_get_spool_calls_afc_error(self):
-        """exception in get_spool → AFC_error called."""
+    def test_none_result_from_get_spool_calls_afc_error(self):
+        """A failed/not-found lookup delivers None to the callback (get_spool
+        already logs its own "not found" message); _apply_spool_data must
+        still report it via AFC_error rather than crashing."""
         spool = self._make_spool_with_spoolman()
         lane = _make_lane()
         lane.remember_spool = False
-        spool.afc.moonraker.get_spool = MagicMock(
-            side_effect=Exception("Connection refused")
-        )
+        _stub_get_spool(spool, None)
         spool.set_spoolID(lane, 42)
-        spool.afc.error.AFC_error.assert_called()
+        spool.afc.error.AFC_error.assert_called_once()
+        assert "42" in spool.afc.error.AFC_error.call_args[0][0]
+
+    def test_exception_while_applying_spool_data_calls_afc_error(self):
+        """An exception raised while processing a successful response (e.g.
+        malformed data) must still be caught and reported, not crash."""
+        spool = self._make_spool_with_spoolman()
+        lane = _make_lane()
+        lane.remember_spool = False
+        _stub_get_spool(spool, {"filament": None})  # .get() on None -> AttributeError
+        spool.set_spoolID(lane, 42)
+        spool.afc.error.AFC_error.assert_called_once()
+
+    def test_get_spool_int_conversion_failure_calls_afc_error(self):
+        """SpoolID that can't convert to int (defensive edge case; normal
+        callers already validate) must be reported, not crash, and must not
+        dispatch a lookup at all."""
+        spool = self._make_spool_with_spoolman()
+        lane = _make_lane()
+        lane.remember_spool = False
+        spool.afc.moonraker.get_spool = MagicMock()
+        spool.set_spoolID(lane, "not-a-number")
+        spool.afc.error.AFC_error.assert_called_once()
+        spool.afc.moonraker.get_spool.assert_not_called()
+
+    def test_valid_spool_id_dispatches_async_lookup_without_blocking(self):
+        """set_spoolID must not block on the lookup: with a callback that
+        never fires, the lane must remain unmodified when set_spoolID returns."""
+        spool = self._make_spool_with_spoolman()
+        lane = _make_lane()
+        lane.remember_spool = False
+        original_spool_id = lane.spool_id
+        spool.afc.moonraker.get_spool = MagicMock()  # never invokes its callback
+
+        spool.set_spoolID(lane, 42)
+
+        spool.afc.moonraker.get_spool.assert_called_once()
+        assert spool.afc.moonraker.get_spool.call_args[0][0] == 42
+        assert lane.spool_id == original_spool_id
+        spool.afc.save_vars.assert_not_called()
+
+    def test_sync_clear_path_calls_on_done(self):
+        """Covers the synchronous branch of set_spoolID (no moonraker lookup
+        needed) still invoking on_done."""
+        spool = _make_spool()
+        lane = _make_lane()
+        lane.remember_spool = False
+        on_done = MagicMock()
+        spool.set_spoolID(lane, "", on_done=on_done)
+        on_done.assert_called_once_with()
+
+    def test_async_path_calls_on_done_via_apply_spool_data(self):
+        """Covers _apply_spool_data's finally block invoking on_done once
+        the async lookup resolves through the real set_spoolID/get_spool wiring."""
+        spool = self._make_spool_with_spoolman()
+        lane = _make_lane()
+        lane.remember_spool = False
+        lane.espooler = MagicMock()
+        _stub_get_spool(spool, _make_spool_result())
+        on_done = MagicMock()
+        spool.set_spoolID(lane, 42, on_done=on_done)
+        on_done.assert_called_once_with()
 
     def test_empty_spool_id_with_spoolman_not_remember_spool_clears_values(self):
         """spoolman not None + SpoolID='' + not remember_spool → clear_values."""
@@ -1737,7 +1805,10 @@ class TestCmdSetSpoolID:
         gcmd = _make_gcmd(LANE="lane1", SPOOL_ID="5")
         spool.set_spoolID = MagicMock()
         spool.cmd_SET_SPOOL_ID(gcmd)
-        spool.set_spoolID.assert_called_once_with(lane1, 5)
+        spool.set_spoolID.assert_called_once()
+        call = spool.set_spoolID.call_args
+        assert call.args == (lane1, 5)
+        assert callable(call.kwargs["on_done"])
 
     def test_no_spoolid_provided_set_spool_id(self):
         spool = _make_spool()
@@ -1749,7 +1820,10 @@ class TestCmdSetSpoolID:
         gcmd = _make_gcmd(LANE="lane1")
         spool.set_spoolID = MagicMock()
         spool.cmd_SET_SPOOL_ID(gcmd)
-        spool.set_spoolID.assert_called_once_with(lane1, '')
+        spool.set_spoolID.assert_called_once()
+        call = spool.set_spoolID.call_args
+        assert call.args == (lane1, '')
+        assert callable(call.kwargs["on_done"])
 
     def test_no_lane_param_logs_info(self):
         """spoolman not None + lane=None → log info + return."""
@@ -1769,7 +1843,9 @@ class TestCmdSetSpoolID:
         assert spool.logger.messages == [("info", "ghost Unknown")]
 
     def test_calls_set_active_spool_when_lane_is_current(self):
-        """cur_lane.name == afc.current → set_active_spool called."""
+        """cur_lane.name == afc.current → set_active_spool called once
+        set_spoolID's on_done callback fires (deferred, since set_spoolID's
+        actual assignment can be async)."""
         spool = _make_spool()
         spool.afc.spoolman = MagicMock()
         lane1 = _make_lane("lane1")
@@ -1779,8 +1855,31 @@ class TestCmdSetSpoolID:
         gcmd = _make_gcmd(LANE="lane1", SPOOL_ID="9")
         spool.set_spoolID = MagicMock()
         spool.set_active_spool = MagicMock()
+
         spool.cmd_SET_SPOOL_ID(gcmd)
-        spool.set_active_spool.assert_called_once_with(lane1.spool_id)
+
+        spool.set_active_spool.assert_not_called()
+        on_done = spool.set_spoolID.call_args.kwargs["on_done"]
+        lane1.spool_id = 9  # simulate set_spoolID having applied the new id
+        on_done()
+        spool.set_active_spool.assert_called_once_with(9)
+
+    def test_does_not_call_set_active_spool_when_lane_not_current(self):
+        spool = _make_spool()
+        spool.afc.spoolman = MagicMock()
+        lane1 = _make_lane("lane1")
+        lane1.spool_id = None
+        spool.afc.lanes = {"lane1": lane1}
+        spool.afc.current = "lane2"  # a different lane is active
+        gcmd = _make_gcmd(LANE="lane1", SPOOL_ID="9")
+        spool.set_spoolID = MagicMock()
+        spool.set_active_spool = MagicMock()
+
+        spool.cmd_SET_SPOOL_ID(gcmd)
+        on_done = spool.set_spoolID.call_args.kwargs["on_done"]
+        on_done()
+
+        spool.set_active_spool.assert_not_called()
 
 
 # ── Auto switch debounce flag reset ──────────────────────────────────────────
@@ -1806,7 +1905,7 @@ class TestAutoSwitchFlagReset:
         spool = _make_spool()
         spool.afc.spoolman = "http://spoolman:7912"
         spool.afc.moonraker = MagicMock()
-        spool.afc.moonraker.get_spool.return_value = {
+        result = {
             'filament': {
                 'material': 'PLA',
                 'settings_extruder_temp': 210,
@@ -1819,6 +1918,7 @@ class TestAutoSwitchFlagReset:
             'spool_weight': 190,
             'initial_weight': 1000,
         }
+        spool.afc.moonraker.get_spool.side_effect = lambda id, callback: callback(result)
         lane = _make_lane("lane1")
         lane.auto_switch_triggered = True
         lane.espooler = MagicMock()

--- a/tests/test_AFC_spool.py
+++ b/tests/test_AFC_spool.py
@@ -18,6 +18,43 @@ import pytest
 from extras.AFC_spool import AFCSpool, load_config
 
 
+# ── Module-level import guard ────────────────────────────────────────────────
+
+class TestNaturalSortKeyImportGuard:
+    def test_raises_configfile_error_when_import_fails(self):
+        """Covers the module-level try/except around importing natural_sort_key
+        from extras.AFC_utils: if that import fails, the module must re-raise
+        as configfile.error rather than a raw ImportError.
+
+        Loads a throwaway copy of the module under a separate name instead of
+        reloading extras.AFC_spool in place: reload() mutates the canonical
+        module's namespace, which would leave every `from extras.AFC_spool
+        import AFCSpool` reference already captured elsewhere in this test
+        suite pointing at a stale, pre-reload class.
+        """
+        import sys
+        import importlib.util
+        from configfile import error as ConfigFileError
+
+        afc_utils = sys.modules["extras.AFC_utils"]
+        real_natural_sort_key = afc_utils.natural_sort_key
+        del afc_utils.natural_sort_key
+        try:
+            spec = importlib.util.spec_from_file_location(
+                "extras.AFC_spool_import_guard_test",
+                sys.modules["extras.AFC_spool"].__file__,
+            )
+            fresh_module = importlib.util.module_from_spec(spec)
+            sys.modules[spec.name] = fresh_module
+            try:
+                with pytest.raises(ConfigFileError):
+                    spec.loader.exec_module(fresh_module)
+            finally:
+                del sys.modules[spec.name]
+        finally:
+            afc_utils.natural_sort_key = real_natural_sort_key
+
+
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
 def _make_spool():
@@ -1617,6 +1654,26 @@ class TestSetSpoolID:
         spool.set_spoolID(lane, 42)
         spool.afc.error.AFC_error.assert_called()
         spool.clear_values.assert_called()
+
+    def test_zero_weight_still_calls_snapmaker_params_save_vars_and_on_done(self):
+        """The invalid-weight early return is inside _apply_spool_data's
+        finally block, so it must not skip these -- same guarantee as the
+        exception and success paths."""
+        spool = self._make_spool_with_spoolman()
+        spool.set_snapmaker_filament_params = MagicMock()
+        lane = _make_lane()
+        lane.remember_spool = False
+        lane.espooler = MagicMock()
+        result = _make_spool_result(weight=0.0)
+        _stub_get_spool(spool, result)
+        spool.disable_weight_check = False
+        on_done = MagicMock()
+
+        spool.set_spoolID(lane, 42, on_done=on_done)
+
+        spool.set_snapmaker_filament_params.assert_called_once_with(lane)
+        spool.afc.save_vars.assert_called_once_with()
+        on_done.assert_called_once_with()
 
     def test_disable_weight_check_skips_validation(self):
         spool = self._make_spool_with_spoolman()

--- a/tests/test_AFC_unit.py
+++ b/tests/test_AFC_unit.py
@@ -13,6 +13,7 @@ Covers:
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, call
 import pytest
 
@@ -1134,3 +1135,139 @@ class TestLaneOrdering:
         unit.handle_ready()
 
         assert list(unit.lanes.keys()) == ["lane1", "lane2", "lane3", "custom_name4", "lane10"]
+
+
+# ── get_td1_data / _apply_td1_data ───────────────────────────────────────────
+
+def _make_td1_lane():
+    lane = _make_lane()
+    lane.td1_device_id = "SN1"
+    lane.td1_data = None
+    return lane
+
+
+def _make_td1_device(scan_time="2024-01-01T12:00:00Z", td="PLA", color="#FF0000"):
+    return {"scan_time": scan_time, "td": td, "color": color}
+
+
+class TestGetTd1Data:
+    def test_fetches_then_delegates_to_apply(self):
+        unit = _make_unit()
+        lane = _make_td1_lane()
+        unit.afc.moonraker = MagicMock()
+        unit.afc.moonraker.get_td1_data.return_value = {"SN1": _make_td1_device()}
+        unit._apply_td1_data = MagicMock(return_value=True)
+        compare_time = datetime.now()
+
+        result = unit.get_td1_data(lane, compare_time, ignore_time=True)
+
+        unit.afc.moonraker.get_td1_data.assert_called_once_with()
+        unit._apply_td1_data.assert_called_once_with(
+            lane, compare_time, {"SN1": _make_td1_device()}, True)
+        assert result is True
+
+
+class TestApplyTd1Data:
+    def test_none_data_returns_false(self):
+        """Covers td1_data being None (a failed fetch) without crashing."""
+        unit = _make_unit()
+        lane = _make_td1_lane()
+        result = unit._apply_td1_data(lane, datetime.now(), None)
+        assert result is False
+
+    def test_empty_data_returns_false(self):
+        unit = _make_unit()
+        lane = _make_td1_lane()
+        result = unit._apply_td1_data(lane, datetime.now(), {})
+        assert result is False
+
+    def test_device_id_not_in_data_logs_error_and_returns_false(self):
+        unit = _make_unit()
+        unit.afc.error.AFC_error = MagicMock()
+        lane = _make_td1_lane()
+        result = unit._apply_td1_data(lane, datetime.now(), {"OTHER": _make_td1_device()})
+        assert result is False
+        unit.afc.error.AFC_error.assert_called_once()
+        assert "SN1" in unit.afc.error.AFC_error.call_args[0][0]
+
+    def test_none_scan_time_returns_false(self):
+        unit = _make_unit()
+        lane = _make_td1_lane()
+        device = _make_td1_device(scan_time=None)
+        result = unit._apply_td1_data(lane, datetime.now(), {"SN1": device})
+        assert result is False
+
+    def test_unparseable_scan_time_logs_error_and_returns_false(self):
+        unit = _make_unit()
+        lane = _make_td1_lane()
+        device = _make_td1_device(scan_time="not-a-timestamp")
+        result = unit._apply_td1_data(lane, datetime.now(), {"SN1": device})
+        assert result is False
+
+    # scan_time (from the device payload) is always parsed as a UTC instant;
+    # compare_time is built the same way here (rather than a naive local
+    # datetime) so these comparisons don't depend on the test machine's
+    # local timezone.
+
+    def test_scan_time_after_compare_time_is_valid_and_applies(self):
+        unit = _make_unit()
+        lane = _make_td1_lane()
+        compare_time = datetime(2024, 1, 1, 11, 0, 0, tzinfo=timezone.utc)
+        device = _make_td1_device(scan_time="2024-01-01T12:00:00Z")
+        result = unit._apply_td1_data(lane, compare_time, {"SN1": device})
+        assert result is True
+        assert lane.td1_data == device
+        unit.afc.save_vars.assert_called_once_with()
+
+    def test_scan_time_shortly_before_compare_time_is_still_valid(self):
+        """Covers the `(compare_time - scan_time) < t_delta` grace-period branch."""
+        unit = _make_unit()
+        lane = _make_td1_lane()
+        compare_time = datetime(2024, 1, 1, 12, 0, 5, tzinfo=timezone.utc)
+        device = _make_td1_device(scan_time="2024-01-01T12:00:00Z")
+        result = unit._apply_td1_data(lane, compare_time, {"SN1": device})
+        assert result is True
+
+    def test_scan_time_already_ending_in_offset_is_parsed(self):
+        """Covers the `scan_time.endswith("+00:00Z")` True branch, distinct
+        from the plain "Z"-suffixed format used by the other tests here."""
+        unit = _make_unit()
+        lane = _make_td1_lane()
+        compare_time = datetime(2024, 1, 1, 11, 0, 0, tzinfo=timezone.utc)
+        device = _make_td1_device(scan_time="2024-01-01T12:00:00+00:00Z")
+        result = unit._apply_td1_data(lane, compare_time, {"SN1": device})
+        assert result is True
+
+    def test_stale_scan_time_without_ignore_time_is_not_valid(self):
+        unit = _make_unit()
+        lane = _make_td1_lane()
+        compare_time = datetime(2024, 1, 1, 13, 0, 0, tzinfo=timezone.utc)
+        device = _make_td1_device(scan_time="2024-01-01T12:00:00Z")
+        result = unit._apply_td1_data(lane, compare_time, {"SN1": device}, ignore_time=False)
+        assert result is False
+        assert lane.td1_data is None
+
+    def test_stale_scan_time_with_ignore_time_still_applies(self):
+        unit = _make_unit()
+        lane = _make_td1_lane()
+        compare_time = datetime(2024, 1, 1, 13, 0, 0, tzinfo=timezone.utc)
+        device = _make_td1_device(scan_time="2024-01-01T12:00:00Z")
+        result = unit._apply_td1_data(lane, compare_time, {"SN1": device}, ignore_time=True)
+        assert result is True
+        assert lane.td1_data == device
+
+    def test_missing_td_skips_apply_even_when_valid(self):
+        unit = _make_unit()
+        lane = _make_td1_lane()
+        device = _make_td1_device(td=None)
+        result = unit._apply_td1_data(lane, datetime.now(), {"SN1": device}, ignore_time=True)
+        assert result is False
+        assert lane.td1_data is None
+
+    def test_missing_color_skips_apply_even_when_valid(self):
+        unit = _make_unit()
+        lane = _make_td1_lane()
+        device = _make_td1_device(color=None)
+        result = unit._apply_td1_data(lane, datetime.now(), {"SN1": device}, ignore_time=True)
+        assert result is False
+        assert lane.td1_data is None

--- a/tests/test_AFC_unit.py
+++ b/tests/test_AFC_unit.py
@@ -1174,35 +1174,55 @@ class TestApplyTd1Data:
         lane = _make_td1_lane()
         result = unit._apply_td1_data(lane, datetime.now(), None)
         assert result is False
+        assert unit.logger.messages == []
 
     def test_empty_data_returns_false(self):
         unit = _make_unit()
         lane = _make_td1_lane()
         result = unit._apply_td1_data(lane, datetime.now(), {})
         assert result is False
+        assert unit.logger.messages == []
 
     def test_device_id_not_in_data_logs_error_and_returns_false(self):
         unit = _make_unit()
-        unit.afc.error.AFC_error = MagicMock()
         lane = _make_td1_lane()
-        result = unit._apply_td1_data(lane, datetime.now(), {"OTHER": _make_td1_device()})
+        compare_time = datetime.now()
+        td1_data = {"OTHER": _make_td1_device()}
+
+        result = unit._apply_td1_data(lane, compare_time, td1_data)
+
         assert result is False
-        unit.afc.error.AFC_error.assert_called_once()
-        assert "SN1" in unit.afc.error.AFC_error.call_args[0][0]
+        assert unit.logger.messages == [
+            ("debug", f"Data: {td1_data}, Compare_time: {compare_time}"),
+            ("error", "TD-1 Device ID (SN1) supplied, but ID not found."),
+        ]
 
     def test_none_scan_time_returns_false(self):
         unit = _make_unit()
         lane = _make_td1_lane()
-        device = _make_td1_device(scan_time=None)
-        result = unit._apply_td1_data(lane, datetime.now(), {"SN1": device})
+        compare_time = datetime.now()
+        td1_data = {"SN1": _make_td1_device(scan_time=None)}
+
+        result = unit._apply_td1_data(lane, compare_time, td1_data)
+
         assert result is False
+        assert unit.logger.messages == [
+            ("debug", f"Data: {td1_data}, Compare_time: {compare_time}"),
+        ]
 
     def test_unparseable_scan_time_logs_error_and_returns_false(self):
         unit = _make_unit()
         lane = _make_td1_lane()
-        device = _make_td1_device(scan_time="not-a-timestamp")
-        result = unit._apply_td1_data(lane, datetime.now(), {"SN1": device})
+        compare_time = datetime.now()
+        td1_data = {"SN1": _make_td1_device(scan_time="not-a-timestamp")}
+
+        result = unit._apply_td1_data(lane, compare_time, td1_data)
+
         assert result is False
+        assert unit.logger.messages == [
+            ("debug", f"Data: {td1_data}, Compare_time: {compare_time}"),
+            ("error", "Error trying to format TD-1 scan time, check AFC.log for more information"),
+        ]
 
     # scan_time (from the device payload) is always parsed as a UTC instant;
     # compare_time is built the same way here (rather than a naive local
@@ -1214,10 +1234,17 @@ class TestApplyTd1Data:
         lane = _make_td1_lane()
         compare_time = datetime(2024, 1, 1, 11, 0, 0, tzinfo=timezone.utc)
         device = _make_td1_device(scan_time="2024-01-01T12:00:00Z")
-        result = unit._apply_td1_data(lane, compare_time, {"SN1": device})
+        td1_data = {"SN1": device}
+
+        result = unit._apply_td1_data(lane, compare_time, td1_data)
+
         assert result is True
         assert lane.td1_data == device
         unit.afc.save_vars.assert_called_once_with()
+        assert unit.logger.messages == [
+            ("debug", f"Data: {td1_data}, Compare_time: {compare_time}"),
+            ("info", f"{lane.name} TD-1 data captured"),
+        ]
 
     def test_scan_time_shortly_before_compare_time_is_still_valid(self):
         """Covers the `(compare_time - scan_time) < t_delta` grace-period branch."""
@@ -1225,8 +1252,15 @@ class TestApplyTd1Data:
         lane = _make_td1_lane()
         compare_time = datetime(2024, 1, 1, 12, 0, 5, tzinfo=timezone.utc)
         device = _make_td1_device(scan_time="2024-01-01T12:00:00Z")
-        result = unit._apply_td1_data(lane, compare_time, {"SN1": device})
+        td1_data = {"SN1": device}
+
+        result = unit._apply_td1_data(lane, compare_time, td1_data)
+
         assert result is True
+        assert unit.logger.messages == [
+            ("debug", f"Data: {td1_data}, Compare_time: {compare_time}"),
+            ("info", f"{lane.name} TD-1 data captured"),
+        ]
 
     def test_scan_time_already_ending_in_offset_is_parsed(self):
         """Covers the `scan_time.endswith("+00:00Z")` True branch, distinct
@@ -1235,39 +1269,71 @@ class TestApplyTd1Data:
         lane = _make_td1_lane()
         compare_time = datetime(2024, 1, 1, 11, 0, 0, tzinfo=timezone.utc)
         device = _make_td1_device(scan_time="2024-01-01T12:00:00+00:00Z")
-        result = unit._apply_td1_data(lane, compare_time, {"SN1": device})
+        td1_data = {"SN1": device}
+
+        result = unit._apply_td1_data(lane, compare_time, td1_data)
+
         assert result is True
+        assert unit.logger.messages == [
+            ("debug", f"Data: {td1_data}, Compare_time: {compare_time}"),
+            ("info", f"{lane.name} TD-1 data captured"),
+        ]
 
     def test_stale_scan_time_without_ignore_time_is_not_valid(self):
         unit = _make_unit()
         lane = _make_td1_lane()
         compare_time = datetime(2024, 1, 1, 13, 0, 0, tzinfo=timezone.utc)
         device = _make_td1_device(scan_time="2024-01-01T12:00:00Z")
-        result = unit._apply_td1_data(lane, compare_time, {"SN1": device}, ignore_time=False)
+        td1_data = {"SN1": device}
+
+        result = unit._apply_td1_data(lane, compare_time, td1_data, ignore_time=False)
+
         assert result is False
         assert lane.td1_data is None
+        assert unit.logger.messages == [
+            ("debug", f"Data: {td1_data}, Compare_time: {compare_time}"),
+        ]
 
     def test_stale_scan_time_with_ignore_time_still_applies(self):
         unit = _make_unit()
         lane = _make_td1_lane()
         compare_time = datetime(2024, 1, 1, 13, 0, 0, tzinfo=timezone.utc)
         device = _make_td1_device(scan_time="2024-01-01T12:00:00Z")
-        result = unit._apply_td1_data(lane, compare_time, {"SN1": device}, ignore_time=True)
+        td1_data = {"SN1": device}
+
+        result = unit._apply_td1_data(lane, compare_time, td1_data, ignore_time=True)
+
         assert result is True
         assert lane.td1_data == device
+        assert unit.logger.messages == [
+            ("debug", f"Data: {td1_data}, Compare_time: {compare_time}"),
+            ("info", f"{lane.name} TD-1 data captured"),
+        ]
 
     def test_missing_td_skips_apply_even_when_valid(self):
         unit = _make_unit()
         lane = _make_td1_lane()
-        device = _make_td1_device(td=None)
-        result = unit._apply_td1_data(lane, datetime.now(), {"SN1": device}, ignore_time=True)
+        compare_time = datetime.now()
+        td1_data = {"SN1": _make_td1_device(td=None)}
+
+        result = unit._apply_td1_data(lane, compare_time, td1_data, ignore_time=True)
+
         assert result is False
         assert lane.td1_data is None
+        assert unit.logger.messages == [
+            ("debug", f"Data: {td1_data}, Compare_time: {compare_time}"),
+        ]
 
     def test_missing_color_skips_apply_even_when_valid(self):
         unit = _make_unit()
         lane = _make_td1_lane()
-        device = _make_td1_device(color=None)
-        result = unit._apply_td1_data(lane, datetime.now(), {"SN1": device}, ignore_time=True)
+        compare_time = datetime.now()
+        td1_data = {"SN1": _make_td1_device(color=None)}
+
+        result = unit._apply_td1_data(lane, compare_time, td1_data, ignore_time=True)
+
         assert result is False
         assert lane.td1_data is None
+        assert unit.logger.messages == [
+            ("debug", f"Data: {td1_data}, Compare_time: {compare_time}"),
+        ]

--- a/tests/test_AFC_utils.py
+++ b/tests/test_AFC_utils.py
@@ -313,9 +313,20 @@ class TestDebounceButton:
 # ── AFC_moonraker ─────────────────────────────────────────────────────────────
 class TestAFCMoonraker:
     def _make_moonraker(self, host="http://localhost", port="7125"):
-        from tests.conftest import MockLogger
+        from tests.conftest import MockLogger, MockReactor
         logger = MockLogger()
-        return AFC_moonraker(host, port, logger)
+        reactor = MockReactor()
+        # Run register_async_callback callbacks immediately by default so most
+        # tests can assert on logger.messages the same way they would if the
+        # log call happened inline; tests that care about the deferral itself
+        # override this to inspect the raw callback instead.
+        reactor.register_async_callback = lambda cb, waketime=None: cb(0.0)
+        mr = AFC_moonraker(host, port, logger, reactor)
+        # The real background writer thread is already parked on the original
+        # queue at this point (blocked in queue.get()); swapping it out here
+        # keeps tests deterministic instead of racing the live thread.
+        mr._write_queue = MagicMock()
+        return mr
 
     def test_init_sets_host_with_port(self):
         mr = self._make_moonraker("http://localhost", "7125")
@@ -363,12 +374,25 @@ class TestAFCMoonraker:
         from extras.AFC_utils import check_and_return
         assert check_and_return("x", {"x": 42}) == 42
 
-    def test_update_afc_stats_logs_on_failure(self):
+    def test_update_afc_stats_queues_sync_write(self):
+        mr = self._make_moonraker()
+        mr.update_afc_stats("some.key", 10)
+        mr._write_queue.put_nowait.assert_called_once_with(
+            (mr._update_afc_stats_sync, ("some.key", 10)))
+
+    def test_update_afc_stats_sync_logs_on_failure(self):
         mr = self._make_moonraker()
         mr._get_results = MagicMock(return_value=None)
-        mr.update_afc_stats("some.key", 10)
+        mr._update_afc_stats_sync("some.key", 10)
         errors = [m for lvl, m in mr.logger.messages if lvl == "error"]
         assert len(errors) == 1
+
+    def test_update_afc_stats_sync_no_error_on_success(self):
+        mr = self._make_moonraker()
+        mr._get_results = MagicMock(return_value={"value": "ok"})
+        mr._update_afc_stats_sync("some.key", 10)
+        errors = [m for lvl, m in mr.logger.messages if lvl == "error"]
+        assert len(errors) == 0
 
     def test_get_spool_not_found_logs_info(self):
         mr = self._make_moonraker()
@@ -478,34 +502,47 @@ class TestAFCMoonraker:
 
     # ── send_lane_data ────────────────────────────────────────────────────────
 
-    def test_send_lane_data_logs_error_on_failure(self):
+    def test_send_lane_data_queues_sync_write(self):
+        mr = self._make_moonraker()
+        data = {"lane1": {"color": "red"}}
+        mr.send_lane_data(data)
+        mr._write_queue.put_nowait.assert_called_once_with(
+            (mr._send_lane_data_sync, (data,)))
+
+    def test_send_lane_data_sync_logs_error_on_failure(self):
         mr = self._make_moonraker()
         mr._get_results = MagicMock(return_value=None)
-        mr.send_lane_data({"lane1": {"color": "red"}})
+        mr._send_lane_data_sync({"lane1": {"color": "red"}})
         errors = [m for lvl, m in mr.logger.messages if lvl == "error"]
         assert len(errors) == 1
 
-    def test_send_lane_data_success_no_error(self):
+    def test_send_lane_data_sync_success_no_error(self):
         mr = self._make_moonraker()
         mr._get_results = MagicMock(return_value={"value": "ok"})
-        mr.send_lane_data({"lane1": {"color": "red"}})
+        mr._send_lane_data_sync({"lane1": {"color": "red"}})
         errors = [m for lvl, m in mr.logger.messages if lvl == "error"]
         assert len(errors) == 0
 
     # ── remove_database_entry ─────────────────────────────────────────────────
 
-    def test_remove_database_entry_calls_urlopen(self):
+    def test_remove_database_entry_queues_sync_write(self):
+        mr = self._make_moonraker()
+        mr.remove_database_entry("lane_data", "lane1")
+        mr._write_queue.put_nowait.assert_called_once_with(
+            (mr._remove_database_entry_sync, ("lane_data", "lane1")))
+
+    def test_remove_database_entry_sync_calls_urlopen(self):
         mr = self._make_moonraker()
         with patch("extras.AFC_utils.urlopen") as mock_urlopen:
-            mr.remove_database_entry("lane_data", "lane1")
+            mr._remove_database_entry_sync("lane_data", "lane1")
         mock_urlopen.assert_called_once()
 
-    def test_remove_database_entry_logs_debug_on_http_error(self):
+    def test_remove_database_entry_sync_logs_debug_on_http_error(self):
         from urllib.error import HTTPError
         mr = self._make_moonraker()
         with patch("extras.AFC_utils.urlopen",
                    side_effect=HTTPError(None, 404, "Not Found", {}, None)):
-            mr.remove_database_entry("lane_data", "missing_key")
+            mr._remove_database_entry_sync("lane_data", "missing_key")
         debug_msgs = [m for lvl, m in mr.logger.messages if lvl == "debug"]
         assert len(debug_msgs) > 0
 
@@ -597,28 +634,16 @@ class TestAFCMoonraker:
         # Two _get_results calls: once per call since refetch was triggered
         assert mr._get_results.call_count == 2
 
-    def test_send_lane_data_http_error_logs_error(self):
-        """Covers lines 432-435: HTTPError propagated from _get_results."""
+    def test_send_lane_data_sync_http_error_logs_error(self):
+        """HTTPError propagated from _get_results."""
         from urllib.error import HTTPError
         mr = self._make_moonraker()
         mr._get_results = MagicMock(
             side_effect=HTTPError(None, 500, "Internal Server Error", {}, None)
         )
-        mr.send_lane_data({"lane1": {"color": "red"}})
+        mr._send_lane_data_sync({"lane1": {"color": "red"}})
         errors = [m for lvl, m in mr.logger.messages if lvl == "error"]
         assert len(errors) >= 1
-
-    def test_delete_lane_data_http_error_logs_debug(self):
-        """Covers lines 473-475: HTTPError raised by remove_database_entry."""
-        from urllib.error import HTTPError
-        mr = self._make_moonraker()
-        mr._get_results = MagicMock(return_value={"value": {"lane1": {}}})
-        mr.remove_database_entry = MagicMock(
-            side_effect=HTTPError(None, 500, "Error", {}, None)
-        )
-        mr.delete_lane_data()
-        debug_msgs = [m for lvl, m in mr.logger.messages if lvl == "debug"]
-        assert len(debug_msgs) >= 1
 
     def test_trigger_db_backup_http_error_returns_true(self):
         """Covers lines 491-495: HTTPError from _get_results in trigger_db_backup."""
@@ -631,6 +656,78 @@ class TestAFCMoonraker:
         assert error is True
         errors = [m for lvl, m in mr.logger.messages if lvl == "error"]
         assert len(errors) >= 1
+
+
+# ── AFC_moonraker background writer ─────────────────────────────────────────
+
+class TestAFCMoonrakerBackgroundWriter:
+    def _make_moonraker_with_real_reactor_hook(self):
+        """Build an AFC_moonraker but capture the register_async_callback
+        call instead of running it immediately, so tests can drive it by hand."""
+        from tests.conftest import MockLogger, MockReactor
+        logger = MockLogger()
+        reactor = MockReactor()
+        reactor.register_async_callback = MagicMock()
+        mr = AFC_moonraker("http://localhost", "7125", logger, reactor)
+        mr._write_queue = MagicMock()
+        return mr
+
+    def test_init_starts_background_writer_thread(self):
+        from tests.conftest import MockLogger, MockReactor
+        mr = AFC_moonraker("http://localhost", "7125", MockLogger(), MockReactor())
+        assert mr._write_thread.is_alive()
+        assert mr._write_thread.daemon is True
+
+    def test_log_async_schedules_callback_on_reactor(self):
+        mr = self._make_moonraker_with_real_reactor_hook()
+        log_fn = MagicMock()
+        mr._log_async(log_fn, "hello", traceback="tb")
+        mr.reactor.register_async_callback.assert_called_once()
+        scheduled_cb = mr.reactor.register_async_callback.call_args[0][0]
+        log_fn.assert_not_called()
+        scheduled_cb(0.0)
+        log_fn.assert_called_once_with("hello", traceback="tb")
+
+    def test_write_worker_processes_queued_call_then_loops(self):
+        """Drives exactly one loop iteration: the second queue.get() raises
+        to break out of the otherwise-infinite loop deterministically."""
+        mr = self._make_moonraker_with_real_reactor_hook()
+        called = []
+        mr._write_queue.get.side_effect = [
+            (lambda a, b: called.append((a, b)), (1, 2)),
+            RuntimeError("stop test loop"),
+        ]
+
+        with pytest.raises(RuntimeError, match="stop test loop"):
+            mr._write_worker()
+
+        assert called == [(1, 2)]
+
+    def test_write_worker_survives_exception_and_logs_it(self):
+        """A queued call that raises must not kill the worker loop -- it
+        should be caught, logged, and the loop must continue to the next item."""
+        mr = self._make_moonraker_with_real_reactor_hook()
+
+        def boom():
+            raise ValueError("kaboom")
+
+        mr._write_queue.get.side_effect = [
+            (boom, ()),
+            RuntimeError("stop test loop"),
+        ]
+
+        with pytest.raises(RuntimeError, match="stop test loop"):
+            mr._write_worker()
+
+        scheduled_calls = mr.reactor.register_async_callback.call_args_list
+        assert len(scheduled_calls) == 2
+        scheduled_calls[0][0][0](0.0)
+        scheduled_calls[1][0][0](0.0)
+        errors = [m for lvl, m in mr.logger.messages if lvl == "error"]
+        debug_msgs = [m for lvl, m in mr.logger.messages if lvl == "debug"]
+        assert errors == ["Unexpected error in moonraker background writer"]
+        assert any("kaboom" in m for m in debug_msgs)
+
 
 # ── AFC_PrintFileMetaData ───────────────────────────────────────────────────
 

--- a/tests/test_AFC_utils.py
+++ b/tests/test_AFC_utils.py
@@ -394,11 +394,20 @@ class TestAFCMoonraker:
         errors = [m for lvl, m in mr.logger.messages if lvl == "error"]
         assert len(errors) == 0
 
-    def test_get_spool_not_found_logs_info(self):
+    def test_get_spool_queues_sync_read(self):
+        mr = self._make_moonraker()
+        callback = MagicMock()
+        mr.get_spool(42, callback)
+        mr._write_queue.put_nowait.assert_called_once_with(
+            (mr._get_spool_sync, (42, callback)))
+        callback.assert_not_called()
+
+    def test_get_spool_sync_not_found_logs_info(self):
         mr = self._make_moonraker()
         mr._get_results = MagicMock(return_value=None)
-        result = mr.get_spool(42)
-        assert result is None
+        callback = MagicMock()
+        mr._get_spool_sync(42, callback)
+        callback.assert_called_once_with(None)
         infos = [m for lvl, m in mr.logger.messages if lvl == "info"]
         assert any("42" in m for m in infos)
 
@@ -582,12 +591,12 @@ class TestAFCMoonraker:
         errors = [m for lvl, m in mr.logger.messages if lvl == "error"]
         assert len(errors) == 1
 
-    def test_get_spool_returns_resp_when_found(self):
-        """Covers line 352: if resp is not None → resp = resp branch in get_spool."""
+    def test_get_spool_sync_returns_resp_when_found(self):
         mr = self._make_moonraker()
         mr._get_results = MagicMock(return_value={"id": 42, "name": "PLA"})
-        result = mr.get_spool(42)
-        assert result == {"id": 42, "name": "PLA"}
+        callback = MagicMock()
+        mr._get_spool_sync(42, callback)
+        callback.assert_called_once_with({"id": 42, "name": "PLA"})
 
     def test_check_for_td1_with_td1_in_config_and_data(self):
         """Covers lines 371-374: td1 in orig config and data returned."""
@@ -776,11 +785,11 @@ class TestAFCPrintFileMetaDataFilename:
         moonraker.get_file_metadata.assert_not_called()
         assert meta.tool_change_count == 0
 
-    def test_setting_empty_filename_calls_on_ready_immediately(self):
+    def test_setting_empty_filename_calls_on_fetched_immediately(self):
         meta, moonraker = _make_print_file_metadata()
-        on_ready = MagicMock()
-        meta.query_filename("", on_ready=on_ready)
-        on_ready.assert_called_once_with()
+        on_fetched = MagicMock()
+        meta.query_filename("", on_fetched=on_fetched)
+        on_fetched.assert_called_once_with()
 
     def test_setting_filename_with_no_moonraker_does_not_raise(self):
         """Covers the `self._moonraker` half of `if self._moonraker and value`
@@ -792,22 +801,22 @@ class TestAFCPrintFileMetaDataFilename:
         assert meta.tool_change_count == 0
         assert meta.tool_temperatures == []
 
-    def test_setting_filename_with_no_moonraker_calls_on_ready_immediately(self):
+    def test_setting_filename_with_no_moonraker_calls_on_fetched_immediately(self):
         from tests.conftest import MockLogger
         meta = AFC_PrintFileMetaData(None, MockLogger())
-        on_ready = MagicMock()
-        meta.query_filename("test.gcode", on_ready=on_ready)
-        on_ready.assert_called_once_with()
+        on_fetched = MagicMock()
+        meta.query_filename("test.gcode", on_fetched=on_fetched)
+        on_fetched.assert_called_once_with()
 
-    def test_query_filename_calls_on_ready_after_metadata_cached(self):
+    def test_query_filename_calls_on_fetched_after_metadata_cached(self):
         meta, moonraker = _make_print_file_metadata()
         _stub_get_file_metadata(moonraker, {"filament_change_count": 3})
         seen_count_at_callback_time = []
 
-        def on_ready():
+        def on_fetched():
             seen_count_at_callback_time.append(meta.tool_change_count)
 
-        meta.query_filename("test.gcode", on_ready=on_ready)
+        meta.query_filename("test.gcode", on_fetched=on_fetched)
         assert seen_count_at_callback_time == [3]
 
     def test_stale_response_for_superseded_filename_is_dropped(self):

--- a/tests/test_AFC_utils.py
+++ b/tests/test_AFC_utils.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import configparser
 import json
+import threading
 from io import StringIO
 from unittest.mock import MagicMock, patch, call
 import pytest
@@ -686,6 +687,7 @@ class TestAFCMoonrakerBackgroundWriter:
         mr = AFC_moonraker("http://localhost", "7125", MockLogger(), MockReactor())
         assert mr._write_thread.is_alive()
         assert mr._write_thread.daemon is True
+        assert mr._write_thread.name == "afc_moonraker"
 
     def test_log_async_schedules_callback_on_reactor(self):
         mr = self._make_moonraker_with_real_reactor_hook()
@@ -736,6 +738,34 @@ class TestAFCMoonrakerBackgroundWriter:
         debug_msgs = [m for lvl, m in mr.logger.messages if lvl == "debug"]
         assert errors == ["Unexpected error in moonraker background writer"]
         assert any("kaboom" in m for m in debug_msgs)
+
+    def test_write_worker_sets_os_thread_name(self):
+        mr = self._make_moonraker_with_real_reactor_hook()
+        mr._write_queue.get.side_effect = [RuntimeError("stop test loop")]
+        fake_ffi_lib = MagicMock()
+
+        with patch("chelper.get_ffi", return_value=(MagicMock(), fake_ffi_lib)):
+            with pytest.raises(RuntimeError, match="stop test loop"):
+                mr._write_worker()
+
+        fake_ffi_lib.set_thread_name.assert_called_once_with(
+            threading.current_thread().name.encode("utf-8"))
+
+    def test_write_worker_survives_exception_setting_thread_name(self):
+        """A failure naming the OS thread (e.g. chelper unavailable) must not
+        stop the worker from processing queued calls."""
+        mr = self._make_moonraker_with_real_reactor_hook()
+        called = []
+        mr._write_queue.get.side_effect = [
+            (lambda a, b: called.append((a, b)), (1, 2)),
+            RuntimeError("stop test loop"),
+        ]
+
+        with patch("chelper.get_ffi", side_effect=Exception("boom")):
+            with pytest.raises(RuntimeError, match="stop test loop"):
+                mr._write_worker()
+
+        assert called == [(1, 2)]
 
 
 # ── AFC_PrintFileMetaData ───────────────────────────────────────────────────

--- a/tests/test_AFC_utils.py
+++ b/tests/test_AFC_utils.py
@@ -528,6 +528,37 @@ class TestAFCMoonraker:
         result = mr.get_td1_data()
         assert result is None
 
+    # ── get_td1_data_async ───────────────────────────────────────────────────
+
+    def test_get_td1_data_async_queues_sync_read(self):
+        mr = self._make_moonraker()
+        callback = MagicMock()
+        mr.get_td1_data_async(callback)
+        mr._write_queue.put_nowait.assert_called_once_with(
+            (mr._get_td1_data_async_sync, (callback,)))
+        callback.assert_not_called()
+
+    def test_get_td1_data_async_sync_returns_devices_on_success(self):
+        mr = self._make_moonraker()
+        mr._get_results = MagicMock(return_value={"devices": {"SN123": {}}})
+        callback = MagicMock()
+        mr._get_td1_data_async_sync(callback)
+        callback.assert_called_once_with({"SN123": {}})
+
+    def test_get_td1_data_async_sync_returns_none_when_no_devices_key(self):
+        mr = self._make_moonraker()
+        mr._get_results = MagicMock(return_value={"other": "data"})
+        callback = MagicMock()
+        mr._get_td1_data_async_sync(callback)
+        callback.assert_called_once_with(None)
+
+    def test_get_td1_data_async_sync_returns_none_on_failure(self):
+        mr = self._make_moonraker()
+        mr._get_results = MagicMock(return_value=None)
+        callback = MagicMock()
+        mr._get_td1_data_async_sync(callback)
+        callback.assert_called_once_with(None)
+
     # ── reboot_td1 ───────────────────────────────────────────────────────────
 
     def test_reboot_td1_returns_response(self):

--- a/tests/test_AFC_utils.py
+++ b/tests/test_AFC_utils.py
@@ -744,6 +744,12 @@ class TestAFCMoonrakerBackgroundWriter:
         reactor = MockReactor()
         reactor.register_async_callback = MagicMock()
         mr = AFC_moonraker("http://localhost", "7125", logger, reactor)
+        # The constructor already started a real worker parked on the real
+        # queue; stop and join it before swapping the queue for a MagicMock,
+        # otherwise it stays blocked on the orphaned real queue forever and
+        # leaks a daemon thread per test.
+        mr._write_queue.put_nowait((mr.sentinel, ()))
+        mr._write_thread.join(timeout=5)
         mr._write_queue = MagicMock()
         return mr
 
@@ -831,6 +837,44 @@ class TestAFCMoonrakerBackgroundWriter:
                 mr._write_worker()
 
         assert called == [(1, 2)]
+
+    def test_join_thread_clears_write_thread_wait_flag(self):
+        mr = self._make_moonraker_with_real_reactor_hook()
+        mr._write_thread_wait = True
+        mr.join_thread()
+        assert mr._write_thread_wait is False
+
+    def test_join_thread_puts_sentinel_on_write_queue(self):
+        mr = self._make_moonraker_with_real_reactor_hook()
+        mr.join_thread()
+        mr._write_queue.put_nowait.assert_called_once_with((mr.sentinel, ""))
+
+    def test_write_worker_returns_on_sentinel_without_calling_it(self):
+        """join_thread queues (sentinel, ""); the worker must return instead
+        of trying to call the sentinel class as a function."""
+        mr = self._make_moonraker_with_real_reactor_hook()
+        mr._write_queue.get.side_effect = [(mr.sentinel, "")]
+
+        result = mr._write_worker()
+
+        assert result is None
+
+    def test_write_worker_stops_looping_once_join_thread_clears_wait_flag(self):
+        """Simulates a real klippy:disconnect: join_thread flips the wait
+        flag and queues the sentinel, and the worker must exit its loop."""
+        mr = self._make_moonraker_with_real_reactor_hook()
+        called = []
+
+        def stop_after_call(a, b):
+            called.append((a, b))
+            mr.join_thread()
+
+        mr._write_queue.get.side_effect = [(stop_after_call, (1, 2))]
+
+        mr._write_worker()
+
+        assert called == [(1, 2)]
+        assert mr._write_thread_wait is False
 
 
 # ── AFC_PrintFileMetaData ───────────────────────────────────────────────────

--- a/tests/test_AFC_utils.py
+++ b/tests/test_AFC_utils.py
@@ -739,6 +739,18 @@ def _make_print_file_metadata(moonraker=None):
     return AFC_PrintFileMetaData(moonraker, logger), moonraker
 
 
+def _stub_get_file_metadata(moonraker, *values):
+    """Makes moonraker.get_file_metadata(filename, callback) invoke callback
+    immediately (as if the async fetch completed inline) with each of
+    `values` in turn, one per call."""
+    remaining = list(values)
+
+    def _side_effect(filename, callback):
+        callback(remaining.pop(0))
+
+    moonraker.get_file_metadata.side_effect = _side_effect
+
+
 class TestAFCPrintFileMetaDataInit:
     def test_init_defaults(self):
         meta, _ = _make_print_file_metadata()
@@ -750,38 +762,81 @@ class TestAFCPrintFileMetaDataInit:
 class TestAFCPrintFileMetaDataFilename:
     def test_setting_filename_queries_moonraker_metadata(self):
         meta, moonraker = _make_print_file_metadata()
-        moonraker.get_file_metadata.return_value = {"filament_change_count": 3}
-        meta.filename = "test.gcode"
-        moonraker.get_file_metadata.assert_called_once_with("test.gcode")
+        _stub_get_file_metadata(moonraker, {"filament_change_count": 3})
+        meta.query_filename("test.gcode")
+        assert moonraker.get_file_metadata.call_count == 1
+        assert moonraker.get_file_metadata.call_args[0][0] == "test.gcode"
         assert meta.filename == "test.gcode"
 
     def test_setting_empty_filename_does_not_query_moonraker(self):
         """Covers the `value` half of `if self._moonraker and value` being falsy
         while `self._moonraker` alone is truthy."""
         meta, moonraker = _make_print_file_metadata()
-        meta.filename = ""
+        meta.query_filename("")
         moonraker.get_file_metadata.assert_not_called()
         assert meta.tool_change_count == 0
+
+    def test_setting_empty_filename_calls_on_ready_immediately(self):
+        meta, moonraker = _make_print_file_metadata()
+        on_ready = MagicMock()
+        meta.query_filename("", on_ready=on_ready)
+        on_ready.assert_called_once_with()
 
     def test_setting_filename_with_no_moonraker_does_not_raise(self):
         """Covers the `self._moonraker` half of `if self._moonraker and value`
         being falsy while `value` alone is truthy."""
         from tests.conftest import MockLogger
         meta = AFC_PrintFileMetaData(None, MockLogger())
-        meta.filename = "test.gcode"
+        meta.query_filename("test.gcode")
         assert meta.filename == "test.gcode"
         assert meta.tool_change_count == 0
         assert meta.tool_temperatures == []
 
+    def test_setting_filename_with_no_moonraker_calls_on_ready_immediately(self):
+        from tests.conftest import MockLogger
+        meta = AFC_PrintFileMetaData(None, MockLogger())
+        on_ready = MagicMock()
+        meta.query_filename("test.gcode", on_ready=on_ready)
+        on_ready.assert_called_once_with()
+
+    def test_query_filename_calls_on_ready_after_metadata_cached(self):
+        meta, moonraker = _make_print_file_metadata()
+        _stub_get_file_metadata(moonraker, {"filament_change_count": 3})
+        seen_count_at_callback_time = []
+
+        def on_ready():
+            seen_count_at_callback_time.append(meta.tool_change_count)
+
+        meta.query_filename("test.gcode", on_ready=on_ready)
+        assert seen_count_at_callback_time == [3]
+
+    def test_stale_response_for_superseded_filename_is_dropped(self):
+        """If filename changed again before an in-flight query's callback
+        fires, the stale response must not clobber the newer state."""
+        meta, moonraker = _make_print_file_metadata()
+        captured_calls = []
+        moonraker.get_file_metadata.side_effect = (
+            lambda filename, callback: captured_calls.append((filename, callback))
+        )
+        meta.query_filename("first.gcode")
+        # Simulate a second query superseding the first before the first's
+        # response has arrived
+        meta.query_filename("second.gcode")
+        # Now the first (stale) query's response finally lands
+        first_filename, first_callback = captured_calls[0]
+        assert first_filename == "first.gcode"
+        first_callback({"filament_change_count": 99})
+        assert meta.filename == "second.gcode"
+        assert meta.tool_change_count == 0
+
     def test_updating_filename_refreshes_metadata(self):
         meta, moonraker = _make_print_file_metadata()
-        moonraker.get_file_metadata.side_effect = [
-            {"filament_change_count": 2},
-            {"filament_change_count": 9},
-        ]
-        meta.filename = "first.gcode"
+        _stub_get_file_metadata(moonraker,
+                                {"filament_change_count": 2},
+                                {"filament_change_count": 9})
+        meta.query_filename("first.gcode")
         assert meta.tool_change_count == 2
-        meta.filename = "second.gcode"
+        meta.query_filename("second.gcode")
         assert meta.tool_change_count == 9
         assert moonraker.get_file_metadata.call_count == 2
 
@@ -790,8 +845,8 @@ class TestAFCPrintFileMetaDataFilename:
         the cached metadata must still behave as an empty dict rather than
         None so downstream property access doesn't operate on None."""
         meta, moonraker = _make_print_file_metadata()
-        moonraker.get_file_metadata.return_value = None
-        meta.filename = "test.gcode"
+        _stub_get_file_metadata(moonraker, None)
+        meta.query_filename("test.gcode")
         assert meta.tool_change_count == 0
         assert meta.tool_temperatures == []
 
@@ -799,13 +854,12 @@ class TestAFCPrintFileMetaDataFilename:
         """A failed query (None) for one filename must not leave stale/bad
         state that breaks a subsequent successful query for another filename."""
         meta, moonraker = _make_print_file_metadata()
-        moonraker.get_file_metadata.side_effect = [
-            None, {"filament_change_count": 7, "filament_temps": [220]},
-        ]
-        meta.filename = "first.gcode"
+        _stub_get_file_metadata(moonraker,
+                                None, {"filament_change_count": 7, "filament_temps": [220]})
+        meta.query_filename("first.gcode")
         assert meta.tool_change_count == 0
         assert meta.tool_temperatures == []
-        meta.filename = "second.gcode"
+        meta.query_filename("second.gcode")
         assert meta.tool_change_count == 7
         assert meta.tool_temperatures == [220]
 
@@ -813,22 +867,22 @@ class TestAFCPrintFileMetaDataFilename:
 class TestAFCPrintFileMetaDataToolChangeCount:
     def test_tool_change_count_from_metadata(self):
         meta, moonraker = _make_print_file_metadata()
-        moonraker.get_file_metadata.return_value = {"filament_change_count": 5}
-        meta.filename = "test.gcode"
+        _stub_get_file_metadata(moonraker, {"filament_change_count": 5})
+        meta.query_filename("test.gcode")
         assert meta.tool_change_count == 5
 
     def test_tool_change_count_default_zero_when_missing(self):
         meta, moonraker = _make_print_file_metadata()
-        moonraker.get_file_metadata.return_value = {}
-        meta.filename = "test.gcode"
+        _stub_get_file_metadata(moonraker, {})
+        meta.query_filename("test.gcode")
         assert meta.tool_change_count == 0
 
     def test_tool_change_count_default_zero_when_metadata_empty_dict(self):
         """Covers the falsy-`self._metadata` half of
         `if self._metadata and "filament_change_count" in self._metadata`."""
         meta, moonraker = _make_print_file_metadata()
-        moonraker.get_file_metadata.return_value = None
-        meta.filename = "test.gcode"
+        _stub_get_file_metadata(moonraker, None)
+        meta.query_filename("test.gcode")
         assert meta.tool_change_count == 0
         debug_msgs = [m for lvl, m in meta.logger.messages if lvl == "debug"]
         assert any("test.gcode" in m for m in debug_msgs)
@@ -837,37 +891,36 @@ class TestAFCPrintFileMetaDataToolChangeCount:
 class TestAFCPrintFileMetaDataToolTemperatures:
     def test_tool_temperatures_from_filament_temps(self):
         meta, moonraker = _make_print_file_metadata()
-        moonraker.get_file_metadata.return_value = {"filament_temps": [200, 210, 220]}
-        meta.filename = "test.gcode"
+        _stub_get_file_metadata(moonraker, {"filament_temps": [200, 210, 220]})
+        meta.query_filename("test.gcode")
         assert meta.tool_temperatures == [200, 210, 220]
 
     def test_tool_temperatures_falls_back_to_nozzle_temp(self):
         """Snapmaker U1 files use `nozzle_temp` instead of `filament_temps`."""
         meta, moonraker = _make_print_file_metadata()
-        moonraker.get_file_metadata.return_value = {"nozzle_temp": [215]}
-        meta.filename = "test.gcode"
+        _stub_get_file_metadata(moonraker, {"nozzle_temp": [215]})
+        meta.query_filename("test.gcode")
         assert meta.tool_temperatures == [215]
 
     def test_tool_temperatures_empty_when_neither_key_present(self):
         meta, moonraker = _make_print_file_metadata()
-        moonraker.get_file_metadata.return_value = {}
-        meta.filename = "test.gcode"
+        _stub_get_file_metadata(moonraker, {})
+        meta.query_filename("test.gcode")
         assert meta.tool_temperatures == []
 
     def test_tool_temperatures_empty_when_metadata_none(self):
         """Covers the falsy-`self._metadata` branch of `if self._metadata`."""
         meta, moonraker = _make_print_file_metadata()
-        moonraker.get_file_metadata.return_value = None
-        meta.filename = "test.gcode"
+        _stub_get_file_metadata(moonraker, None)
+        meta.query_filename("test.gcode")
         assert meta.tool_temperatures == []
 
 class TestAFCPrintFileMetaDataReset:
     def test_reset_clears_filename_and_metadata(self):
         meta, moonraker = _make_print_file_metadata()
-        moonraker.get_file_metadata.return_value = {
-            "filament_change_count": 4, "filament_temps": [200, 210],
-        }
-        meta.filename = "test.gcode"
+        _stub_get_file_metadata(moonraker,
+                                {"filament_change_count": 4, "filament_temps": [200, 210]})
+        meta.query_filename("test.gcode")
         meta.reset()
         assert meta.filename == ""
         assert meta.tool_change_count == 0

--- a/tests/test_AFC_utils.py
+++ b/tests/test_AFC_utils.py
@@ -383,17 +383,19 @@ class TestAFCMoonraker:
 
     def test_update_afc_stats_sync_logs_on_failure(self):
         mr = self._make_moonraker()
+        init_messages = list(mr.logger.messages)
         mr._get_results = MagicMock(return_value=None)
         mr._update_afc_stats_sync("some.key", 10)
-        errors = [m for lvl, m in mr.logger.messages if lvl == "error"]
-        assert len(errors) == 1
+        assert mr.logger.messages == init_messages + [
+            ("error", "Error when trying to update some.key in moonraker, see AFC.log for more info"),
+        ]
 
     def test_update_afc_stats_sync_no_error_on_success(self):
         mr = self._make_moonraker()
+        init_messages = list(mr.logger.messages)
         mr._get_results = MagicMock(return_value={"value": "ok"})
         mr._update_afc_stats_sync("some.key", 10)
-        errors = [m for lvl, m in mr.logger.messages if lvl == "error"]
-        assert len(errors) == 0
+        assert mr.logger.messages == init_messages
 
     def test_get_spool_queues_sync_read(self):
         mr = self._make_moonraker()

--- a/tests/test_AFC_utils.py
+++ b/tests/test_AFC_utils.py
@@ -412,6 +412,38 @@ class TestAFCMoonraker:
         infos = [m for lvl, m in mr.logger.messages if lvl == "info"]
         assert any("42" in m for m in infos)
 
+    def test_get_file_metadata_queues_sync_read(self):
+        mr = self._make_moonraker()
+        callback = MagicMock()
+        mr.get_file_metadata("test.gcode", callback)
+        mr._write_queue.put_nowait.assert_called_once_with(
+            (mr._get_file_metadata_sync, ("test.gcode", callback)))
+        callback.assert_not_called()
+
+    def test_get_file_metadata_sync_returns_resp_when_found(self):
+        mr = self._make_moonraker()
+        mr._get_results = MagicMock(return_value={"filament_change_count": 3})
+        callback = MagicMock()
+        mr._get_file_metadata_sync("test.gcode", callback)
+        callback.assert_called_once_with({"filament_change_count": 3})
+
+    def test_get_file_metadata_sync_returns_none_on_failure(self):
+        mr = self._make_moonraker()
+        mr._get_results = MagicMock(return_value=None)
+        callback = MagicMock()
+        mr._get_file_metadata_sync("test.gcode", callback)
+        callback.assert_called_once_with(None)
+
+    def test_get_file_metadata_sync_queries_correct_url(self):
+        from urllib.parse import urljoin, quote
+        mr = self._make_moonraker()
+        mr._get_results = MagicMock(return_value=None)
+        mr._get_file_metadata_sync("sub dir/test file.gcode", MagicMock())
+        queried_url = mr._get_results.call_args[0][0]
+        expected_url = urljoin(
+            mr.host, f"{mr.FILENAME_PATH}{quote('sub dir/test file.gcode')}")
+        assert queried_url == expected_url
+
     def test_get_spoolman_server_returns_none_when_missing(self):
         mr = self._make_moonraker()
         mr._get_results = MagicMock(return_value={"orig": {}})


### PR DESCRIPTION
## Major Changes in this PR
- To help cut down on AFC blocking klippers main reactor thread, new threads have been created in AFC for saving variables to afc.vars.unit file and a thread has been created for moonraker communication. Some of the startup communications (like getting stats) have been left to fetch synchronously since this only happens during the init phase. 
- These changes were done with Claude's help to make sure that they were done correctly

Closes #831 

## Notes to Code Reviewers
- Alot of the code was moved around into new methods, so they could be called asynchronously correctly. 

## How the changes in this PR are tested
@rescosta Has been testing these changes https://github.com/AFCProject/AFC-Klipper-Add-On/issues/831#issuecomment-5376168920, tested on my machine to verify no ill effects are seen,
- Also verified that threads are named correctly in mainline klipper and that the threads get cleaned up correctly if someone just saves and resets a file.

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to pr-review channel requesting review
- [x] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved responsiveness through asynchronous Moonraker communication and variable-file updates.
  * Added asynchronous spool assignment, print metadata retrieval, and TD-1 sensor handling.
  * Improved lane status tracking, LED effects, and spool illumination.
  * Updated AFC version to 1.2.7.

* **Bug Fixes**
  * Added safeguards for failed, missing, outdated, or invalid responses.
  * Improved homing and saved-position safety checks.
  * Improved background-operation error reporting and recovery.

* **Documentation**
  * Added a changelog entry describing these improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->