### PR TITLE
Fix issue 806 boolean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [09-03-2026]
+### Fixed
+- Setting `remember_spool` to `False` will now actually set it to `False`.
+
 ## [08-31-2026]
 ### Fixed
 - `install-afc.sh` / `update-afc.sh` now resolve the add-on directory from the script's own

--- a/extras/AFC_unit.py
+++ b/extras/AFC_unit.py
@@ -77,7 +77,7 @@ class afcUnit:
         self.extruder                    = config.get("extruder", None)                                      # Extruder name(AFC_extruder) that belongs to this unit, can be overridden in AFC_stepper section
         self.buffer_name                 = config.get('buffer', None)                                        # Buffer name(AFC_buffer) that belongs to this unit, can be overridden in AFC_stepper section
 
-        self.remember_spool              = config.get('remember_spool', False)                               # Turns on/off ability to remember last ejected spool values for all lanes in this unit, can be overridden in AFC_stepper section
+        self.remember_spool              = config.getboolean('remember_spool', False)                        # Turns on/off ability to remember last ejected spool values for all lanes in this unit, can be overridden in AFC_stepper section
         # LED SETTINGS
         # All variables use: (R,G,B,W) 0 = off, 1 = full brightness. Setting value here overrides values set in AFC.cfg file
         self.led_fault                   = config.get('led_fault', self.afc.led_fault)                       # LED color to set when faults occur in lane

--- a/tests/test_AFC_unit.py
+++ b/tests/test_AFC_unit.py
@@ -13,9 +13,8 @@ Covers:
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from unittest.mock import MagicMock, call
-import pytest
 
 from extras.AFC_unit import afcUnit
 
@@ -79,6 +78,16 @@ def _make_lane(name="lane1", hub="hub1", extruder="ext1", buffer_name="buf1"):
     lane.led_spool_index = None
     lane.current_led_state = ""
     return lane
+
+
+def _make_configured_unit(values):
+    """Build an afcUnit through its real __init__ so config parsing is
+    exercised. `values` maps config option -> raw value, mimicking what a
+    user wrote in the `[AFC_BoxTurtle ...]` section."""
+    from tests.conftest import MockConfig, MockPrinter
+    printer = MockPrinter()
+    config = MockConfig(name="AFC_BoxTurtle Turtle_1", printer=printer, values=values)
+    return afcUnit(config)
 
 
 # ── __str__ ───────────────────────────────────────────────────────────────────
@@ -1337,3 +1346,29 @@ class TestApplyTd1Data:
         assert unit.logger.messages == [
             ("debug", f"Data: {td1_data}, Compare_time: {compare_time}"),
         ]
+
+
+# ── remember_spool config parsing (issue #806) ───────────────────────────────
+
+class TestRememberSpoolConfig:
+    """Unit-level `remember_spool` must be read as a boolean. It used to be
+    read with `config.get`, which returns the raw string "False" when the
+    option is present; lanes then inherit it via `bool(unit.remember_spool)`
+    and `bool("False")` is True -- silently inverting an explicit opt-out."""
+
+    def test_explicit_false_is_boolean_false(self):
+        unit = _make_configured_unit({"remember_spool": "False"})
+        assert unit.remember_spool is False
+
+    def test_explicit_false_does_not_inherit_as_true(self):
+        """The lane inheritance step: `bool(unit_obj.remember_spool)`."""
+        unit = _make_configured_unit({"remember_spool": "False"})
+        assert bool(unit.remember_spool) is False
+
+    def test_explicit_true_is_boolean_true(self):
+        unit = _make_configured_unit({"remember_spool": "True"})
+        assert unit.remember_spool is True
+
+    def test_absent_option_defaults_to_false(self):
+        unit = _make_configured_unit({})
+        assert unit.remember_spool is False

--- a/tests/test_AFC_unit.py
+++ b/tests/test_AFC_unit.py
@@ -80,7 +80,7 @@ def _make_lane(name="lane1", hub="hub1", extruder="ext1", buffer_name="buf1"):
     return lane
 
 
-def _make_configured_unit(values):
+def _make_configured_unit(values: dict[str, object]) -> afcUnit:
     """Build an afcUnit through its real __init__ so config parsing is
     exercised. `values` maps config option -> raw value, mimicking what a
     user wrote in the `[AFC_BoxTurtle ...]` section."""


### PR DESCRIPTION
## Major Changes in this PR

Fix issue 806 with `config.getboolean` instead of `config.get`

Closes #806 

## Notes to Code Reviewers

This is pretty basic. 

Claude made some tests.

## How the changes in this PR are tested

Tests.

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to pr-review channel requesting review
- [x] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed the `remember_spool` setting so explicitly configuring it as `False` now correctly disables spool remembering.
  - Ensured `remember_spool` correctly interprets both `True` and `False` configuration values.
  - Preserved the default behavior of `remember_spool` being disabled when no value is provided.

- **Tests**
  - Added coverage for explicit and default `remember_spool` settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->