### PR TITLE
Fix issue 793 tuple expectations

### DIFF
--- a/tests/test_AFC_buffer.py
+++ b/tests/test_AFC_buffer.py
@@ -3257,7 +3257,7 @@ class TestFPSEnableBuffer:
         lane.extruder_obj = MagicMock(th_extruder_name="extruder")
         buf._lane_has_rotation_control = MagicMock(return_value=True)
         buf.fault_detection_enabled = MagicMock(return_value=False)
-        buf._saved_multipliers["extruder"] = ("some_other_lane", 1.08)
+        buf._saved_multipliers[("extruder", lane.name)] = ("some_other_lane", 1.08)
         buf.set_multiplier = MagicMock()
         buf._last_multiplier = 99.0
         buf.enable_buffer(lane)
@@ -3270,10 +3270,12 @@ class TestFPSEnableBuffer:
         lane.extruder_obj = MagicMock(th_extruder_name="extruder")
         buf._lane_has_rotation_control = MagicMock(return_value=True)
         buf.fault_detection_enabled = MagicMock(return_value=False)
-        buf._saved_multipliers["extruder"] = (lane.name, 1.0)
+        buf._saved_multipliers[("extruder", lane.name)] = (lane.name, 1.0)
         buf.set_multiplier = MagicMock()
+        buf._last_multiplier = 99.0
         buf.enable_buffer(lane)
         buf.set_multiplier.assert_not_called()
+        assert buf._last_multiplier == 1.0
 
     def test_has_stepper_with_fault_detection_starts_it(self):
         buf, afc, reactor, printer = _make_fps_buffer()


### PR DESCRIPTION
## Major Changes in this PR

`_saved_multipliers` expects both `extruder_name` and `lane.name`, but only 1 was being passed. This fixes it.

Closes #793 
## Notes to Code Reviewers

## How the changes in this PR are tested

It is a test.

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [ ] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to pr-review channel requesting review
- [x] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated FPS buffer tests to reflect lane-specific saved multiplier handling.
  * Added coverage confirming the last multiplier resets to 1.0 when the buffer is enabled with a multiplier of one.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->