### PR TITLE
Fix afc_test_lanes using wrong macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [09-04-2026]
+### Fixed
+- Fixed an issue where the `AFC_TEST_LANES` macro would potentially call the wrong PARK macro if a custom macro was
+  defined by the user.
+
 ## [09-03-2026]
 ### Fixed
 - Setting `remember_spool` to `False` will now actually set it to `False`.

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -1204,6 +1204,11 @@ class afcFunction:
             self.logger.info('Toolhead must be unloaded to run tests.')
             return
 
+        error_str = self.afc.verify_macro_positions()
+        if error_str:
+            self.logger.error(error_str)
+            return
+
         prompt = AFCprompt(gcmd, self.logger)
         buttons = []
         title = 'AFC Test Lanes'
@@ -1269,7 +1274,8 @@ class afcFunction:
         prompt.p_end()
 
         if lane is not None:
-            self.afc.gcode.run_script_from_command('AFC_PARK')
+            if self.afc.park and self.afc.park_cmd is not None:
+                self.afc.gcode.run_script_from_command(self.afc.park_cmd)
             self.logger.info('Starting test for lane(s): {}'.format(lane))
             lane_obj = self.afc.lanes.get(lane)
             if lane != 'all':

--- a/extras/AFC_functions.py
+++ b/extras/AFC_functions.py
@@ -1274,7 +1274,8 @@ class afcFunction:
         prompt.p_end()
 
         if lane is not None:
-            if self.afc.park and self.afc.park_cmd is not None:
+            if (self.afc.park
+                and self.afc.park_cmd):
                 self.afc.gcode.run_script_from_command(self.afc.park_cmd)
             self.logger.info('Starting test for lane(s): {}'.format(lane))
             lane_obj = self.afc.lanes.get(lane)

--- a/tests/test_AFC_functions.py
+++ b/tests/test_AFC_functions.py
@@ -1996,3 +1996,71 @@ class TestCheckTd1IdInData:
         valid, msg = func._check_td1_id_in_data({"SN1": {"error": "jam"}}, "SN1")
         assert valid is False
         assert "jam" in msg
+
+
+# ── AFC_TEST_LANES: park_cmd / verify_macro_positions ─────────────────────────
+# A user who overrides `park_cmd` with their own park macro previously still had
+# the hard-coded `AFC_PARK` macro invoked by the lane test. The test must instead
+# honour `self.afc.park_cmd`, only park when `self.afc.park` is enabled, and skip
+# the run entirely when macro positions have not been configured.
+
+class TestCmdAfcTestLanesParkAndVerify:
+    def _make_loaded(self, func):
+        lane = _make_afc_lane()
+        lane._load_state = True
+        lane.prep_state = True
+        func.afc.lanes = {lane.name: lane}
+        func.afc.current = None
+        return lane
+
+    # cmd_AFC_TEST_LANES: verify_macro_positions guard
+
+    def test_aborts_when_macro_positions_not_set(self):
+        from tests.conftest import MockGCodeCommand
+        func = _make_func()
+        self._make_loaded(func)
+        err = "park is set to True and variable_park_loc_xy has not been updated.\n"
+        func.afc.verify_macro_positions = MagicMock(return_value=err)
+
+        with patch("extras.AFC_functions.AFCprompt") as mocked_prompt:
+            func.cmd_AFC_TEST_LANES(MockGCodeCommand())
+
+        mocked_prompt.assert_not_called()
+        assert ("error", err) in func.logger.messages
+
+    def test_creates_prompt_when_macro_positions_ok(self):
+        from tests.conftest import MockGCodeCommand
+        func = _make_func()
+        self._make_loaded(func)
+        func.afc.verify_macro_positions = MagicMock(return_value="")
+
+        with patch("extras.AFC_functions.AFCprompt") as mocked_prompt:
+            func.cmd_AFC_TEST_LANES(MockGCodeCommand())
+
+        func.afc.verify_macro_positions.assert_called_once_with()
+        mocked_prompt.return_value.create_custom_p.assert_called_once()
+
+    # cmd_TEST_LANE: park invocation
+
+    def _run_test_lane(self, func, park, park_cmd):
+        from tests.conftest import MockGCodeCommand
+        func.afc.park = park
+        func.afc.park_cmd = park_cmd
+        gcmd = MockGCodeCommand(params={"LANE": "lane1", "ITERATION": 0})
+        with patch("extras.AFC_functions.AFCprompt"):
+            func.cmd_TEST_LANE(gcmd)
+
+    def test_parks_with_user_configured_park_cmd(self):
+        func = _make_func()
+        self._run_test_lane(func, park=True, park_cmd="MY_PARK")
+        func.afc.gcode.run_script_from_command.assert_called_once_with("MY_PARK")
+
+    def test_does_not_park_when_park_disabled(self):
+        func = _make_func()
+        self._run_test_lane(func, park=False, park_cmd="MY_PARK")
+        func.afc.gcode.run_script_from_command.assert_not_called()
+
+    def test_does_not_park_when_park_cmd_unset(self):
+        func = _make_func()
+        self._run_test_lane(func, park=True, park_cmd=None)
+        func.afc.gcode.run_script_from_command.assert_not_called()


### PR DESCRIPTION
## Major Changes in this PR

Fix issue 852 where `AFC_TEST_LANES` would always call `AFC_PARK`.

Closes #852 

## Notes to Code Reviewers

## How the changes in this PR are tested

Automated testing.

## PR Checklist: (Checked-off items are either done or do not apply to this PR)
 
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md is updated (if end-user facing)
- [ ] Documentation updated in AT-Documentation repository
- [x] Sent notification to pr-review channel requesting review
- [x] If this PR address a GitHub issue, the issue number is referenced in the PR description

**NOTE**: GitHub Copilot may be used for automated code reviews, however as it is an automated system, it's suggestions 
may not be correct. Please do not rely on it to catch all issues. Please review any suggestions it makes and use your 
own judgement to determine if they are correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Lane testing now stops safely and logs an error when macro positions are invalid.
  * Lane testing uses the configured parking command rather than an unintended default.
  * Parking is skipped when disabled or when no parking command is configured.
* **Documentation**
  * Added a changelog entry documenting the macro-selection fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->